### PR TITLE
v.1.0.1 client, sync pagination changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+ * Change `client.py` and `sync.py` to remove `Items-Total` response header from pagination logic.
+
 ## 1.0.0
  * Releasing from Beta --> GA
 

--- a/README.md
+++ b/README.md
@@ -302,35 +302,34 @@ This tap:
     Check tap resulted in the following:
     ```bash
     The output is valid.
-    It contained 228 messages for 16 streams.
+    It contained 265 messages for 16 streams.
 
-        17 schema messages
-        167 record messages
+        18 schema messages
+        203 record messages
         44 state messages
 
     Details by stream:
     +----------------------+---------+---------+
     | stream               | records | schemas |
     +----------------------+---------+---------+
-    | deposit_transactions | 9       | 1       |
-    | cards                | 1       | 2       |
-    | clients              | 102     | 1       |
-    | loan_products        | 2       | 1       |
-    | branches             | 2       | 1       |
-    | deposit_products     | 1       | 1       |
-    | centres              | 2       | 1       |
-    | users                | 3       | 1       |
-    | credit_arrangements  | 2       | 1       |
+    | tasks                | 8       | 1       |
+    | cards                | 1       | 3       |
+    | loan_transactions    | 9       | 1       |
+    | deposit_transactions | 31      | 1       |
+    | custom_field_sets    | 21      | 1       |
+    | groups               | 3       | 1       |
     | communications       | 1       | 1       |
-    | deposit_accounts     | 2       | 1       |
-    | custom_field_sets    | 19      | 1       |
-    | loan_transactions    | 6       | 1       |
-    | groups               | 2       | 1       |
-    | tasks                | 7       | 1       |
-    | loan_accounts        | 6       | 1       |
-    | gl_accounts          | 7       | 1       |
-    | gl_journal_entries   | 267     | 1       |
+    | branches             | 2       | 1       |
+    | credit_arrangements  | 2       | 1       |
+    | loan_products        | 2       | 1       |
+    | centres              | 2       | 1       |
+    | clients              | 104     | 1       |
+    | loan_accounts        | 7       | 1       |
+    | users                | 3       | 1       |
+    | deposit_products     | 4       | 1       |
+    | deposit_accounts     | 3       | 1       |
     +----------------------+---------+---------+
+
     ```
 ---
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='1.0.0',
+      version='1.0.1',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mambu/client.py
+++ b/tap_mambu/client.py
@@ -194,10 +194,4 @@ class MambuClient(object):
         if response.status_code != 200:
             raise_for_error(response)
 
-        # paginationDetails=ON returns items-total as a header parameter in the response headers
-        # Pagination: https://api.mambu.com/?http#pagination
-        total_records = None
-        if kwargs:
-            if 'paginationDetails=ON' in kwargs['params']:
-                total_records = int(response.headers.get('items-total', 0))
-        return response.json(), total_records
+        return response.json()


### PR DESCRIPTION
# Description of change
Change `client.py` and `sync.py` to remove `Items-Total` response header from pagination logic.
Changed pagination from looping to Items-Total header (total_records), to looping while page size record count equals page size limit (loop until fewer records - or no records - are returned).
This request was made by Mambu who is adjusting their API to remove the `Items-Total` header which was previously used in the pagination logic.

# Manual QA steps
Ran singer-check-tap, discovery mode, target-stitch initial load and incremental. Also decreased default page-size limit to 5 records to verify pagination on all endpoints. No issues. Changed default page-size limit back to 500 after tests.
 
# Risks
Currently in production. Low risk - minor changes to client/pagination logic.

# Rollback steps
Revert to v1.0.0
