### PR TITLE
v.1.0.2 Revert, re-apply paging changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.2
+ * Fix merge issue with `v.1.0.1`. Revert to `v.1.0.0 `and re-apply pagination changes.
+
 ## 1.0.1
  * Change `client.py` and `sync.py` to remove `Items-Total` response header from pagination logic.
 

--- a/README.md
+++ b/README.md
@@ -302,34 +302,35 @@ This tap:
     Check tap resulted in the following:
     ```bash
     The output is valid.
-    It contained 265 messages for 16 streams.
+    It contained 586 messages for 18 streams.
 
-        18 schema messages
-        203 record messages
-        44 state messages
+        24 schema messages
+        500 record messages
+        62 state messages
 
     Details by stream:
     +----------------------+---------+---------+
     | stream               | records | schemas |
     +----------------------+---------+---------+
-    | tasks                | 8       | 1       |
-    | cards                | 1       | 3       |
     | loan_transactions    | 9       | 1       |
-    | deposit_transactions | 31      | 1       |
-    | custom_field_sets    | 21      | 1       |
-    | groups               | 3       | 1       |
     | communications       | 1       | 1       |
-    | branches             | 2       | 1       |
-    | credit_arrangements  | 2       | 1       |
     | loan_products        | 2       | 1       |
-    | centres              | 2       | 1       |
-    | clients              | 104     | 1       |
+    | tasks                | 8       | 1       |
+    | deposit_transactions | 31      | 1       |
+    | gl_accounts          | 18      | 5       |
+    | cards                | 1       | 3       |
     | loan_accounts        | 7       | 1       |
-    | users                | 3       | 1       |
-    | deposit_products     | 4       | 1       |
+    | credit_arrangements  | 2       | 1       |
     | deposit_accounts     | 3       | 1       |
+    | clients              | 104     | 1       |
+    | custom_field_sets    | 21      | 1       |
+    | deposit_products     | 4       | 1       |
+    | gl_journal_entries   | 279     | 1       |
+    | centres              | 2       | 1       |
+    | branches             | 2       | 1       |
+    | groups               | 3       | 1       |
+    | users                | 3       | 1       |
     +----------------------+---------+---------+
-
     ```
 ---
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='1.0.1',
+      version='1.0.2',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mambu/client.py
+++ b/tap_mambu/client.py
@@ -193,5 +193,6 @@ class MambuClient(object):
 
         if response.status_code != 200:
             raise_for_error(response)
-
+        
         return response.json()
+

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import singer
 from singer import metrics, metadata, Transformer, utils
-from singer.utils import strptime_to_utc
+from singer.utils import strptime_to_utc, strftime
 from tap_mambu.transform import transform_json
 
 LOGGER = singer.get_logger()
@@ -26,21 +26,27 @@ def write_record(stream_name, record, time_extracted):
         raise err
 
 
-def get_bookmark(state, stream, default):
+def get_bookmark(state, stream, sub_type, default):
     if (state is None) or ('bookmarks' not in state):
         return default
-    return (
-        state
-        .get('bookmarks', {})
-        .get(stream, default)
-    )
+
+    if sub_type == 'self':
+        return (state.get('bookmarks', {}).get(stream, default))
+    else:
+        return (state.get('bookmarks', {}).get(stream, {}).get(sub_type, default))
 
 
-def write_bookmark(state, stream, value):
+def write_bookmark(state, stream, sub_type, value):
     if 'bookmarks' not in state:
         state['bookmarks'] = {}
-    state['bookmarks'][stream] = value
-    LOGGER.info('Write state for stream: {}, value: {}'.format(stream, value))
+    if stream not in state['bookmarks']:
+        state['bookmarks'][stream] = {}
+    if sub_type == 'self':
+        state['bookmarks'][stream] = value
+    else:
+        if sub_type not in state['bookmarks'][stream]:
+            state['bookmarks'][stream][sub_type] = {}
+        state['bookmarks'][stream][sub_type] = value
     singer.write_state(state)
 
 
@@ -118,6 +124,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                   api_version,
                   api_method,
                   static_params,
+                  sub_type,
                   bookmark_query_field=None,
                   bookmark_field=None,
                   bookmark_type=None,
@@ -133,10 +140,10 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
     last_integer = None
     max_bookmark_value = None
     if bookmark_type == 'integer':
-        last_integer = get_bookmark(state, stream_name, 0)
+        last_integer = get_bookmark(state, stream_name, sub_type, 0)
         max_bookmark_value = last_integer
     else:
-        last_datetime = get_bookmark(state, stream_name, start_date)
+        last_datetime = get_bookmark(state, stream_name, sub_type, start_date)
         max_bookmark_value = last_datetime
 
     write_schema(catalog, stream_name)
@@ -164,8 +171,8 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
             elif bookmark_type == 'integer':
                 params[bookmark_query_field] = last_integer
 
-        LOGGER.info('{} - Sync start {}'.format(
-            stream_name,
+        LOGGER.info('Stream: {}, Type: {} - Sync start {}'.format(
+            stream_name, sub_type,
             'since: {}, '.format(last_datetime) if bookmark_query_field else ''))
 
         # Squash params to query-string params
@@ -206,7 +213,6 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
         elif data_key in data:
             transformed_data = transform_json(data, data_key)[data_key]
         # LOGGER.info('transformed_data = {}'.format(transformed_data))  # TESTING, comment out
-
         if not transformed_data or transformed_data is None:
             record_count = 0
             LOGGER.warning('Stream: {} - NO TRANSFORMED DATA RESULTS')
@@ -265,6 +271,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                             api_version=child_endpoint_config.get('api_version', 'v2'),
                             api_method=child_endpoint_config.get('api_method', 'GET'),
                             static_params=child_endpoint_config.get('params', {}),
+                            sub_type=sub_type,
                             bookmark_query_field=child_endpoint_config.get('bookmark_query_field'),
                             bookmark_field=child_endpoint_config.get('bookmark_field'),
                             bookmark_type=child_endpoint_config.get('bookmark_type'),
@@ -282,6 +289,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
         if bookmark_field:
             write_bookmark(state,
                            stream_name,
+                           sub_type,
                            max_bookmark_value)
 
         # to_rec: to record; ending record for the batch
@@ -345,27 +353,17 @@ def sync(client, config, catalog, state):
     # LOGGER.info('start_date = {}'.format(start_date))
 
     # Get datetimes for endpoint parameters
-    communications_dttm_str = get_bookmark(state, 'communications', start_date)
+    communications_dttm_str = get_bookmark(state, 'communications', 'self', start_date)
     communications_dt_str = transform_datetime(communications_dttm_str)[:10]
     # LOGGER.info('communications bookmark_date = {}'.format(communications_dt_str))
 
-    deposit_transactions_dttm_str = get_bookmark(state, 'deposit_transactions', start_date)
+    deposit_transactions_dttm_str = get_bookmark(state, 'deposit_transactions', 'self', start_date)
     deposit_transactions_dt_str = transform_datetime(deposit_transactions_dttm_str)[:10]
     # LOGGER.info('deposit_transactions bookmark_date = {}'.format(deposit_transactions_dt_str))
 
-    loan_transactions_dttm_str = get_bookmark(state, 'loan_transactions', start_date)
+    loan_transactions_dttm_str = get_bookmark(state, 'loan_transactions', 'self', start_date)
     loan_transactions_dt_str = transform_datetime(loan_transactions_dttm_str)[:10]
     # LOGGER.info('loan_transactions bookmark_date = {}'.format(loan_transactions_dt_str))
-
-    selected_streams = get_selected_streams(catalog)
-    LOGGER.info('selected_streams: {}'.format(selected_streams))
-
-    if not selected_streams:
-        return
-
-    # last_stream = Previous currently synced stream, if the load was interrupted
-    last_stream = singer.get_currently_syncing(state)
-    LOGGER.info('last/currently syncing stream: {}'.format(last_stream))
 
     # endpoints: API URL endpoints to be called
     # properties:
@@ -618,8 +616,42 @@ def sync(client, config, catalog, state):
             'bookmark_field': 'last_modified_date',
             'bookmark_type': 'datetime',
             'id_fields': ['id']
+        },
+        'gl_accounts': {
+            'path': 'glaccounts',
+            'api_version': 'v1',
+            'api_method': 'GET',
+            'params': {
+                'type': '{sub_type}'
+            },
+            'id_fields': ['gl_code'],
+            'bookmark_field': 'last_modified_date',
+            'bookmark_type': 'datetime',
+            'sub_types': ['ASSET', 'LIABILITY', 'EQUITY', 'INCOME', 'EXPENSE']
+        },
+        'gl_journal_entries': {
+            'path': 'gljournalentries',
+            'api_version': 'v1',
+            'api_method': 'GET',
+            'params' : {
+                'from': '{gl_journal_entries_from_dt_str}',
+                'to': '{now_date_str}'
+            },
+            'id_fields': ['entry_id'],
+            'bookmark_field': 'booking_date',
+            'bookmark_type': 'datetime'
         }
     }
+
+    selected_streams = get_selected_streams(catalog)
+    LOGGER.info('selected_streams: {}'.format(selected_streams))
+
+    if not selected_streams:
+        return
+
+    # last_stream = Previous currently synced stream, if the load was interrupted
+    last_stream = singer.get_currently_syncing(state)
+    LOGGER.info('last/currently syncing stream: {}'.format(last_stream))
 
     # For each endpoint (above), determine if the stream should be streamed
     #   (based on the catalog and last_stream), then sync those streams.
@@ -627,30 +659,53 @@ def sync(client, config, catalog, state):
         should_stream, last_stream = should_sync_stream(selected_streams,
                                                         last_stream,
                                                         stream_name)
-        if should_stream:
-            LOGGER.info('START Syncing: {}'.format(stream_name))
-            update_currently_syncing(state, stream_name)
-            path = endpoint_config.get('path')
-            total_records = sync_endpoint(
-                client=client,
-                catalog=catalog,
-                state=state,
-                start_date=start_date,
-                stream_name=stream_name,
-                path=path,
-                endpoint_config=endpoint_config,
-                api_version=endpoint_config.get('api_version', 'v2'),
-                api_method=endpoint_config.get('api_method', 'GET'),
-                static_params=endpoint_config.get('params', {}),
-                bookmark_query_field=endpoint_config.get('bookmark_query_field'),
-                bookmark_field=endpoint_config.get('bookmark_field'),
-                bookmark_type=endpoint_config.get('bookmark_type'),
-                data_key=endpoint_config.get('data_key', None),
-                body=endpoint_config.get('body', None),
-                id_fields=endpoint_config.get('id_fields'))
 
-            update_currently_syncing(state, None)
-            LOGGER.info('Synced: {}, total_records: {}'.format(
-                            stream_name, 
-                            total_records))
-            LOGGER.info('FINISHED Syncing: {}'.format(stream_name))
+        if should_stream:
+            # loop through each sub type
+            sub_types = endpoint_config.get('sub_types', ['self'])
+            for sub_type in sub_types:
+                LOGGER.info('START Syncing: {}, Type: {}'.format(stream_name, sub_type))
+
+                # Now date 
+                if stream_name == 'gl_journal_entries':
+                    now_date_str = strftime(utils.now())[:10]
+                    gl_journal_entries_from_dttm_str = get_bookmark(state, 'gl_journal_entries', sub_type, start_date)
+                    gl_journal_entries_from_dt_str = transform_datetime(gl_journal_entries_from_dttm_str)[:10]
+
+                update_currently_syncing(state, stream_name)
+                path = endpoint_config.get('path')
+                sub_type_param = endpoint_config.get('params', {}).get('type')
+                if sub_type_param:
+                    endpoint_config['params']['type'] = sub_type
+
+                gl_journal_entries_from_param = endpoint_config.get('params', {}).get('from')
+                if gl_journal_entries_from_param:
+                    endpoint_config['params']['from'] = gl_journal_entries_from_dt_str
+                gl_journal_entries_to_param = endpoint_config.get('params', {}).get('to')
+                if gl_journal_entries_to_param:
+                    endpoint_config['params']['to'] = now_date_str
+
+                total_records = sync_endpoint(
+                    client=client,
+                    catalog=catalog,
+                    state=state,
+                    start_date=start_date,
+                    stream_name=stream_name,
+                    path=path,
+                    endpoint_config=endpoint_config,
+                    api_version=endpoint_config.get('api_version', 'v2'),
+                    api_method=endpoint_config.get('api_method', 'GET'),
+                    static_params=endpoint_config.get('params', {}),
+                    sub_type=sub_type,
+                    bookmark_query_field=endpoint_config.get('bookmark_query_field'),
+                    bookmark_field=endpoint_config.get('bookmark_field'),
+                    bookmark_type=endpoint_config.get('bookmark_type'),
+                    data_key=endpoint_config.get('data_key', None),
+                    body=endpoint_config.get('body', None),
+                    id_fields=endpoint_config.get('id_fields'))
+
+                update_currently_syncing(state, None)
+                LOGGER.info('Synced: {}, total_records: {}'.format(
+                                stream_name, 
+                                total_records))
+                LOGGER.info('FINISHED Syncing: {}'.format(stream_name))


### PR DESCRIPTION
# Description of change
Fix merge issue with `v.1.0.1` where processing of 2 endpoints were inadvertently removed. Revert to `v.1.0.0 `and re-apply pagination changes.

# Manual QA steps
Ran singer-check-tap, discovery, initial load and incremental load to target-stitch. Verified ALL endpoints loaded for each run.
 
# Risks
Low - reverting to previous working version, 1.0.0, and applying pagination changes only.
 
# Rollback steps
Revert to v.1.0.0
