### PR TITLE
Fix process_record to return the size of the response

### DIFF
--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -110,7 +110,7 @@ def process_records(catalog, #pylint: disable=too-many-branches
                     write_record(stream_name, transformed_record, time_extracted=time_extracted)
                     counter.increment()
 
-        return max_bookmark_value, counter.value
+        return max_bookmark_value, len(records)
 
 
 # Sync a specific parent or child endpoint.


### PR DESCRIPTION
# Description of change
The tap currently decides to stop paginating when the last response returned less than the requested number of records. In the loop to process the response, it sets the variable tracking the number of records in the last response to the number of records the tap emits. So when the tap emits less than 500 records (the limit) because of a bookmark, it thinks it got back less than 500 records, which is the pagination termination condition.

This PR changes `process_records()` to return the length of the response.

# Manual QA steps
 - Ran the tap with and without the change with the same state. Without the change, the tap emits 1 record. With the change, the tap emits most of the records as it paginates.
 - Only tested the `clients` stream
 
# Risks
 - Low, the tap is currently in a broken state
 
# Rollback steps
 - revert this branch and bump the version
