### PR TITLE
Add page_size as a configurable parameter to mitigate 504 errors

### DIFF
--- a/tap_mambu/__init__.py
+++ b/tap_mambu/__init__.py
@@ -19,6 +19,8 @@ REQUIRED_CONFIG_KEYS = [
     'user_agent'
 ]
 
+DEFAULT_PAGE_SIZE = 500
+
 def do_discover():
 
     LOGGER.info('Starting discover')
@@ -35,7 +37,8 @@ def main():
     with MambuClient(parsed_args.config['username'],
                      parsed_args.config['password'],
                      parsed_args.config['subdomain'],
-                     parsed_args.config['user_agent']) as client:
+                     int(parsed_args.config.get('page_size', DEFAULT_PAGE_SIZE)),
+                     user_agent=parsed_args.config['user_agent']) as client:
 
         state = {}
         if parsed_args.state:

--- a/tap_mambu/client.py
+++ b/tap_mambu/client.py
@@ -100,12 +100,14 @@ class MambuClient(object):
                  username,
                  password,
                  subdomain,
+                 page_size,
                  user_agent=None):
         self.__username = username
         self.__password = password
         self.__subdomain = subdomain
         base_url = "https://{}.mambu.com/api".format(subdomain)
         self.base_url = base_url
+        self.page_size = page_size
         self.__user_agent = user_agent
         self.__session = requests.Session()
         self.__verified = False

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -154,7 +154,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
     # Increase the "offset" by the "limit" for each batch.
     # Continue until the "record_count" returned < "limit" is null/zero or 
     offset = 0 # Starting offset value for each batch API call
-    limit = 500 # Batch size; Number of records per API call
+    limit = client.page_size # Batch size; Number of records per API call
     total_records = 0 # Initialize total
     record_count = limit # Initialize, reset for each API call
 


### PR DESCRIPTION
# Description of change

A gateway timeout appears to occur when the old limit of 500 was used
so we should be able to configure this value as needed.

# Manual QA steps
 - Tested this with the affected client and confirmed a lower values allowed data to flow.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
