### PR TITLE
New endpoints and update existing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0
+  * Added endpoints: activities, index rate sources, installments. Client, Groups, GL Journal Entries endpoints changed.
+
 ## 1.1.2
   * Added lookback window for loan transactions stream.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This tap:
   - Bookmark: last_modified_date (date-time)
 - Transformations: Fields camelCase to snake_case, Abstract/generalize custom_field_sets
 
-[**clients (GET v2)**](https://api.mambu.com/?http#clients-getAll)
+[**clients (GET v2)**](https://api.mambu.com/?http#clients-search)
 - Endpoint: https://instance.sandbox.mambu.com/api/clients
 - Primary keys: id
 - Foreign keys: assigned_user_key (users), assigned_centre_key (centres), custom_field_set_id, custom_field_id (custom_field_sets)
@@ -116,7 +116,7 @@ This tap:
   - Bookmark: creation_date (date-time)
 - Transformations: Fields camelCase to snake_case
 
-[**groups (GET v2)**](https://api.mambu.com/?http#groups-getAll)
+[**groups (GET v2)**](https://api.mambu.com/?http#groups-search)
 - Endpoint: https://instance.sandbox.mambu.com/api/groups
 - Primary keys: id
 - Foreign keys: client_key (clients), assigned_branch_key (branches), assigned_centre_key (centers), assigned_user_key (users), custom_field_set_id, custom_field_id (custom_field_sets)
@@ -178,12 +178,34 @@ This tap:
   - Bookmark: last_modified_date (date-time)
 - Transformations: Fields camelCase to snake_case, Abstract/generalize custom_field_sets
 
-[**gl_journal_entries (GET v1)**](https://support.mambu.com/docs/gl-journal-entries-api)
-- Endpoint: https://instance.sandbox.mambu.com/api/gljournalentries
+[**gl_journal_entries (POST v1)**](https://support.mambu.com/docs/en/gl-journal-entries-api#post-search)
+- Endpoint: https://instance.sandbox.mambu.com/api/gljournalentries/search
 - Primary keys: entry_id
 - Replication strategy: Incremental (query filtered based on date)
   - Bookmark: booking_date (date-time)
 - Transformations: Fields camelCase to snake_case, Abstract/generalize custom_field_sets
+
+[**activities (GET v1)**](https://support.mambu.com/docs/activities-api)
+- Endpoint: https://instance.sandbox.mambu.com/api/activities
+- Primary keys: encoded_key
+- Replication strategy: Incremental (query all, filter results)
+  - Bookmark query field: timestamp
+  - Bookmark: timestamp (date-time)
+- Transformations: Fields camelCase to snake_case, de-nest activity
+
+[**index rate sources (GET v2)**](https://api.mambu.com/#index-rate-sources-getallindexratesources)
+- Endpoint: https://instance.sandbox.mambu.com/api/indexratesources
+- Primary keys: encoded_key
+- Replication strategy: Full table
+- Transformations: Fields camelCase to snake_case
+
+[**installments (GET v2)**](https://api.mambu.com/#mambu-api-v2-installments)
+- Endpoint: https://instance.sandbox.mambu.com/api/installments
+- Primary keys: encoded_key
+- Replication strategy: Incremental (query all, filter results)
+  - Bookmark query field: last_paid_date
+  - Bookmark: last_paid_date (date-time)
+- Transformations: Fields camelCase to snake_case
 
 ## Quick Start
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='1.1.2',
+      version='1.2.0',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mambu/schema.py
+++ b/tap_mambu/schema.py
@@ -91,17 +91,17 @@ STREAMS = {
         'key_properties': ['gl_code'],
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['last_modified_date']
-     },
-     'gl_journal_entries': {
+    },
+    'gl_journal_entries': {
         'key_properties': ['entry_id'],
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['booking_date']
-     },
+    },
     'activities': {
         'key_properties': ['encoded_key'],
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['timestamp']
-     },
+    },
     'index_rate_sources': {
         'key_properties': ['encoded_key'],
         'replication_method': 'FULL_TABLE'

--- a/tap_mambu/schema.py
+++ b/tap_mambu/schema.py
@@ -96,7 +96,21 @@ STREAMS = {
         'key_properties': ['entry_id'],
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['booking_date']
-     }
+     },
+    'activities': {
+        'key_properties': ['encoded_key'],
+        'replication_method': 'INCREMENTAL',
+        'replication_keys': ['timestamp']
+     },
+    'index_rate_sources': {
+        'key_properties': ['encoded_key'],
+        'replication_method': 'FULL_TABLE'
+    },
+    'installments': {
+        'key_properties': ['encoded_key'],
+        'replication_method': 'INCREMENTAL',
+        'replication_keys': ['last_paid_date']
+    }
 }
 
 

--- a/tap_mambu/schemas/activities.json
+++ b/tap_mambu/schemas/activities.json
@@ -1,0 +1,85 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "branch_name": {
+            "type": ["null", "string"]
+        },
+        "client_name": {
+            "type": ["null", "string"]
+        },
+        "loan_product_name": {
+            "type": ["null", "string"]
+        },
+        "loan_account_name": {
+            "type": ["null", "string"]
+        },
+        "user_name": {
+            "type": ["null", "string"]
+        },
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "transaction_ID": {
+            "type": ["null", "integer"]
+        },
+        "timestamp": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "type": {
+            "type": ["null", "string"]
+        },
+        "client_key": {
+            "type": ["null", "string"]
+        },
+        "user_key": {
+            "type": ["null", "string"]
+        },
+        "notes": {
+            "type": ["null", "string"]
+        },
+        "field_changes": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "id": {
+                                "type": ["null", "integer"]
+                            },
+                            "transaction_id": {
+                                "type": ["null", "integer"]
+                            },
+                            "field_change_name": {
+                                "type": ["null", "string"]
+                            },
+                            "original_value": {
+                                "type": ["null", "string"]
+                            },
+                            "new_value": {
+                                "type": ["null", "string"]
+                            },
+                            "clientKey": {
+                                "type": ["null", "string"]
+                            },
+                            "branchKey": {
+                                "type": ["null", "string"]
+                            },
+                            "loanProductKey": {
+                                "type": ["null", "string"]
+                            },
+                            "loanAccountKey": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        }
+    }
+}

--- a/tap_mambu/schemas/index_rate_sources.json
+++ b/tap_mambu/schemas/index_rate_sources.json
@@ -1,0 +1,18 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "name": {
+            "type": ["null", "string"]
+        },
+        "notes": {
+            "type": ["null", "string"]
+        },
+        "type": {
+            "type": ["null", "string"]
+        }
+    }
+}

--- a/tap_mambu/schemas/installments.json
+++ b/tap_mambu/schemas/installments.json
@@ -1,0 +1,240 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "number": {
+            "type": ["null", "string"]
+        },
+        "due_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "last_paid_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "repaid_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "state": {
+            "type": ["null", "string"]
+        },
+        "fee": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "amount": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "expected": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "paid": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "due": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        }
+                    }
+                },
+                "tax": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "expected": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "paid": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "due": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        }
+                    }
+                }
+            }
+        },
+        "penalty": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "amount": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "expected": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "paid": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "due": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        }
+                    }
+                },
+                "tax": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "expected": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "paid": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "due": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        }
+                    }
+                }
+            }
+        },
+        "interest": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "amount": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "expected": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "paid": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "due": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        }
+                    }
+                },
+                "tax": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "expected": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "paid": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "due": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        }
+                    }
+                }
+            }
+        },
+        "principal": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "amount": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "expected": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "paid": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        },
+                        "due": {
+                            "type": [
+                                "null",
+                                "number"
+                            ],
+                            "multipleOf": 1e-10
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -214,7 +214,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
             transformed_data = transform_json(data, stream_name)
         elif data_key in data:
             transformed_data = transform_json(data, data_key)[data_key]
-        
+      
         if stream_name == 'activities':
             transformed_data = transform_activities(transformed_data)
 
@@ -754,34 +754,46 @@ def sync(client, config, catalog, state):
                 # Now date
                 if stream_name == 'gl_journal_entries':
                     now_date_str = strftime(utils.now())[:10]
-                    gl_journal_entries_from_dttm_str = get_bookmark(state, 'gl_journal_entries', sub_type, start_date)
-                    gl_journal_entries_from_dt_str = transform_datetime(gl_journal_entries_from_dttm_str)[:10]
-                    gl_journal_entries_from_param = endpoint_config.get('body', {}).get('filterConstraints', {})[0].get('value')
+                    gl_journal_entries_from_dttm_str = get_bookmark(
+                        state, 'gl_journal_entries', sub_type, start_date)
+                    gl_journal_entries_from_dt_str = transform_datetime(
+                        gl_journal_entries_from_dttm_str)[:10]
+                    gl_journal_entries_from_param = endpoint_config.get(
+                        'body', {}).get('filterConstraints', {})[0].get('value')
                     if gl_journal_entries_from_param:
                         endpoint_config['body']['filterConstraints'][0]['value'] = gl_journal_entries_from_dt_str
-                    gl_journal_entries_to_param = endpoint_config.get('body', {}).get('filterConstraints', {})[0].get('secondValue')
+                    gl_journal_entries_to_param = endpoint_config.get(
+                        'body', {}).get('filterConstraints', {})[0].get('secondValue')
                     if gl_journal_entries_to_param:
                         endpoint_config['body']['filterConstraints'][0]['secondValue'] = now_date_str
 
                 if stream_name == 'activities':
                     now_date_str = strftime(utils.now())[:10]
-                    activities_from_dttm_str = get_bookmark(state, 'activities', sub_type, start_date)
-                    activities_from_dt_str = transform_datetime(activities_from_dttm_str)[:10]
-                    activities_from_param = endpoint_config.get('params', {}).get('from')
+                    activities_from_dttm_str = get_bookmark(
+                        state, 'activities', sub_type, start_date)
+                    activities_from_dt_str = transform_datetime(
+                        activities_from_dttm_str)[:10]
+                    activities_from_param = endpoint_config.get(
+                        'params', {}).get('from')
                     if activities_from_param:
                         endpoint_config['params']['from'] = activities_from_dt_str
-                    activities_to_param = endpoint_config.get('params', {}).get('to')
+                    activities_to_param = endpoint_config.get(
+                        'params', {}).get('to')
                     if activities_to_param:
                         endpoint_config['params']['to'] = now_date_str
 
                 if stream_name == 'installments':
                     now_date_str = strftime(utils.now())[:10]
-                    installments_from_dttm_str = get_bookmark(state, 'installments', sub_type, start_date)
-                    installments_from_dt_str = transform_datetime(installments_from_dttm_str)[:10]
-                    installments_from_param = endpoint_config.get('params', {}).get('dueFrom')
+                    installments_from_dttm_str = get_bookmark(
+                        state, 'installments', sub_type, start_date)
+                    installments_from_dt_str = transform_datetime(
+                        installments_from_dttm_str)[:10]
+                    installments_from_param = endpoint_config.get(
+                        'params', {}).get('dueFrom')
                     if installments_from_param:
                         endpoint_config['params']['dueFrom'] = installments_from_dt_str
-                    installments_to_param = endpoint_config.get('params', {}).get('dueTo')
+                    installments_to_param = endpoint_config.get(
+                        'params', {}).get('dueTo')
                     if installments_to_param:
                         endpoint_config['params']['dueTo'] = now_date_str
 

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import singer
 from singer import Transformer, metadata, metrics, utils
 from singer.utils import strftime, strptime_to_utc
-from tap_mambu.transform import transform_json
+from tap_mambu.transform import transform_json, transform_activities
 
 LOGGER = singer.get_logger()
 LOOKBACK_DEFAULT = 14
@@ -214,6 +214,10 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
             transformed_data = transform_json(data, stream_name)
         elif data_key in data:
             transformed_data = transform_json(data, data_key)[data_key]
+        
+        if stream_name == 'activities':
+            transformed_data = transform_activities(transformed_data)
+
         # LOGGER.info('transformed_data = {}'.format(transformed_data))  # TESTING, comment out
         if not transformed_data or transformed_data is None:
             record_count = 0
@@ -366,6 +370,13 @@ def sync(client, config, catalog, state):
     loan_transactions_dttm_str = get_bookmark(state, 'loan_transactions', 'self', start_date)
     loan_transactions_dt_str = transform_datetime(loan_transactions_dttm_str)[:10]
     loan_transactions_dttm = strptime_to_utc(loan_transactions_dt_str)
+
+    clients_dttm_str = get_bookmark(state, 'clients', 'self', start_date)
+    clients_dt_str = transform_datetime(clients_dttm_str)[:10]
+
+    groups_dttm_str = get_bookmark(state, 'groups', 'self', start_date)
+    groups_dt_str = transform_datetime(groups_dttm_str)[:10]
+
     lookback_days = int(config.get('lookback_window', LOOKBACK_DEFAULT))
     lookback_date = utils.now() - timedelta(lookback_days)
     if loan_transactions_dttm > lookback_date:
@@ -440,12 +451,24 @@ def sync(client, config, catalog, state):
             'id_fields': ['id']
         },
         'clients': {
-            'path': 'clients',
+            'path': 'clients:search',
             'api_version': 'v2',
-            'api_method': 'GET',
+            'api_method': 'POST',
             'params': {
-                'sortBy': 'lastModifiedDate:ASC',
                 'detailsLevel': 'FULL'
+            },
+            'body': {
+                "sortingCriteria": {
+                    "field": "lastModifiedDate",
+                    "order": "ASC"
+                },
+                "filterCriteria": [
+                    {
+                        "field": "lastModifiedDate",
+                        "operator": "AFTER",
+                        "value": clients_dt_str
+                    }
+                ]
             },
             'bookmark_field': 'last_modified_date',
             'bookmark_type': 'datetime',
@@ -532,12 +555,24 @@ def sync(client, config, catalog, state):
             'id_fields': ['encoded_key']
         },
         'groups': {
-            'path': 'groups',
+            'path': 'groups:search',
             'api_version': 'v2',
-            'api_method': 'GET',
+            'api_method': 'POST',
             'params': {
-                'sortBy': 'lastModifiedDate:ASC',
                 'detailsLevel': 'FULL'
+            },
+            'body': {
+                "sortingCriteria": {
+                    "field": "lastModifiedDate",
+                    "order": "ASC"
+                },
+                "filterCriteria": [
+                    {
+                        "field": "lastModifiedDate",
+                        "operator": "AFTER",
+                        "value": groups_dt_str
+                    }
+                ]
             },
             'bookmark_field': 'last_modified_date',
             'bookmark_type': 'datetime',
@@ -643,15 +678,52 @@ def sync(client, config, catalog, state):
             'sub_types': ['ASSET', 'LIABILITY', 'EQUITY', 'INCOME', 'EXPENSE']
         },
         'gl_journal_entries': {
-            'path': 'gljournalentries',
+            'path': 'gljournalentries/search',
             'api_version': 'v1',
-            'api_method': 'GET',
-            'params' : {
-                'from': '{gl_journal_entries_from_dt_str}',
-                'to': '{now_date_str}'
+            'api_method': 'POST',
+            'body': {
+                "filterConstraints": [
+                    {
+                        "filterSelection": "CREATION_DATE",
+                        "filterElement": "BETWEEN",
+                        "value": '{gl_journal_entries_from_dt_str}',
+                        "secondValue": "{now_date_str}"
+                    }
+                ]
             },
             'id_fields': ['entry_id'],
             'bookmark_field': 'booking_date',
+            'bookmark_type': 'datetime'
+        },
+        'activities': {
+            'path': 'activities',
+            'api_version': 'v1',
+            'api_method': 'GET',
+            'params' : {
+                'from': '{activities_from_dt_str}',
+                'to': '{now_date_str}'
+            },
+            'id_fields': ['encoded_key'],
+            'bookmark_field': 'timestamp',
+            'bookmark_type': 'datetime'
+        },
+        'index_rate_sources': {
+            'path': 'indexratesources',
+            'api_version': 'v2',
+            'api_method': 'GET',
+            'id_fields': ['encoded_key'],
+            'params': {}
+        },
+        'installments': {
+            'path': 'installments',
+            'api_version': 'v2',
+            'api_method': 'GET',
+            'id_fields': ['encoded_key'],
+            'params': {
+                'dueFrom': '{installments_from_dt_str}',
+                'dueTo': '{now_date_str}'
+            },
+            'bookmark_field': 'last_paid_date',
             'bookmark_type': 'datetime'
         }
     }
@@ -684,6 +756,35 @@ def sync(client, config, catalog, state):
                     now_date_str = strftime(utils.now())[:10]
                     gl_journal_entries_from_dttm_str = get_bookmark(state, 'gl_journal_entries', sub_type, start_date)
                     gl_journal_entries_from_dt_str = transform_datetime(gl_journal_entries_from_dttm_str)[:10]
+                    gl_journal_entries_from_param = endpoint_config.get('body', {}).get('filterConstraints', {})[0].get('value')
+                    if gl_journal_entries_from_param:
+                        endpoint_config['body']['filterConstraints'][0]['value'] = gl_journal_entries_from_dt_str
+                    gl_journal_entries_to_param = endpoint_config.get('body', {}).get('filterConstraints', {})[0].get('secondValue')
+                    if gl_journal_entries_to_param:
+                        endpoint_config['body']['filterConstraints'][0]['secondValue'] = now_date_str
+
+                if stream_name == 'activities':
+                    now_date_str = strftime(utils.now())[:10]
+                    activities_from_dttm_str = get_bookmark(state, 'activities', sub_type, start_date)
+                    activities_from_dt_str = transform_datetime(activities_from_dttm_str)[:10]
+                    activities_from_param = endpoint_config.get('params', {}).get('from')
+                    if activities_from_param:
+                        endpoint_config['params']['from'] = activities_from_dt_str
+                    activities_to_param = endpoint_config.get('params', {}).get('to')
+                    if activities_to_param:
+                        endpoint_config['params']['to'] = now_date_str
+
+                if stream_name == 'installments':
+                    now_date_str = strftime(utils.now())[:10]
+                    installments_from_dttm_str = get_bookmark(state, 'installments', sub_type, start_date)
+                    installments_from_dt_str = transform_datetime(installments_from_dttm_str)[:10]
+                    installments_from_param = endpoint_config.get('params', {}).get('dueFrom')
+                    if installments_from_param:
+                        endpoint_config['params']['dueFrom'] = installments_from_dt_str
+                    installments_to_param = endpoint_config.get('params', {}).get('dueTo')
+                    if installments_to_param:
+                        endpoint_config['params']['dueTo'] = now_date_str
+
 
                 update_currently_syncing(state, stream_name)
                 path = endpoint_config.get('path')
@@ -691,12 +792,6 @@ def sync(client, config, catalog, state):
                 if sub_type_param:
                     endpoint_config['params']['type'] = sub_type
 
-                gl_journal_entries_from_param = endpoint_config.get('params', {}).get('from')
-                if gl_journal_entries_from_param:
-                    endpoint_config['params']['from'] = gl_journal_entries_from_dt_str
-                gl_journal_entries_to_param = endpoint_config.get('params', {}).get('to')
-                if gl_journal_entries_to_param:
-                    endpoint_config['params']['to'] = now_date_str
 
                 total_records = sync_endpoint(
                     client=client,

--- a/tap_mambu/transform.py
+++ b/tap_mambu/transform.py
@@ -83,4 +83,3 @@ def transform_activities(this_json):
             record[key] = value
         del record['activity']
     return this_json
-

--- a/tap_mambu/transform.py
+++ b/tap_mambu/transform.py
@@ -75,3 +75,12 @@ def transform_json(this_json, path):
     out[path] = new_json
     transformed_json = convert_json(out)
     return transformed_json[path]
+
+
+def transform_activities(this_json):
+    for record in this_json:
+        for key, value in record['activity'].items():
+            record[key] = value
+        del record['activity']
+    return this_json
+


### PR DESCRIPTION
# Description of change

This updates:

* Client stream to use https://api.mambu.com/#clients-search
* Group stream to use https://api.mambu.com/#groups-search
* GL Journal Entries to use https://support.mambu.com/docs/en/gl-journal-entries-api#post-search

This adds endpoints:

* Activities: https://support.mambu.com/docs/en/activities-api
* Index rate sources: https://api.mambu.com/#mambu-api-v2-index-rate-sources
* Installments: https://api.mambu.com/#mambu-api-v2-installments

# Manual QA steps
Ran:

1. Discover
```
~/.virtualenvs/tap-mambu/bin/tap-mambu --config tap_config.json --discover | ~/.virtualenvs/singer-discover/bin/singer-discover --output catalog.json
INFO Starting discover
INFO Finished discover
INFO Catalog configuration starting...
? Select Streams  done (22 selections)
? Select fields from stream: `branches`  done (11 selections)
? Select fields from stream: `cards`  done
? Select fields from stream: `communications`  done (21 selections)
? Select fields from stream: `centres`  done (10 selections)
? Select fields from stream: `clients`  done (27 selections)
? Select fields from stream: `credit_arrangements`  done (15 selections)
? Select fields from stream: `custom_field_sets`  done (9 selections)
? Select fields from stream: `deposit_accounts`  done (35 selections)
? Select fields from stream: `deposit_products`  done (37 selections)
? Select fields from stream: `deposit_transactions`  done (27 selections)
? Select fields from stream: `groups`  done (18 selections)
? Select fields from stream: `loan_accounts`  done (53 selections)
? Select fields from stream: `loan_repayments`  done (17 selections)
? Select fields from stream: `loan_products`  done (68 selections)
? Select fields from stream: `loan_transactions`  done (29 selections)
? Select fields from stream: `tasks`  done (13 selections)
? Select fields from stream: `users`  done (18 selections)
? Select fields from stream: `gl_accounts`  done (12 selections)
? Select fields from stream: `gl_journal_entries`  done (11 selections)
? Select fields from stream: `activities`  done (12 selections)
? Select fields from stream: `index_rate_sources`  done (3 selections)
? Select fields from stream: `installments`  done (9 selections)
INFO Catalog configuration saved.
```

2. Singer Check Tap
```
Checking stdin for valid Singer-formatted data
The output is valid.
It contained 1018 messages for 22 streams.

     34 schema messages
    914 record messages
     70 state messages

Details by stream:
+----------------------+---------+---------+
| stream               | records | schemas |
+----------------------+---------+---------+
| branches             | 2       | 1       |
| communications       | 1       | 1       |
| centres              | 2       | 1       |
| clients              | 104     | 1       |
| credit_arrangements  | 2       | 1       |
| custom_field_sets    | 21      | 1       |
| deposit_accounts     | 3       | 1       |
| cards                | 1       | 3       |
| deposit_products     | 4       | 1       |
| deposit_transactions | 39      | 1       |
| groups               | 3       | 1       |
| loan_accounts        | 7       | 1       |
| loan_repayments      | 35      | 7       |
| loan_products        | 2       | 1       |
| loan_transactions    | 9       | 1       |
| tasks                | 8       | 1       |
| users                | 3       | 1       |
| gl_accounts          | 18      | 5       |
| gl_journal_entries   | 295     | 1       |
| activities           | 345     | 1       |
| index_rate_sources   | 0       | 1       |
| installments         | 10      | 1       |
+----------------------+---------+---------+
```

3. Ran initial sync - Singer Target Stitch with no state
Resulting state:
```
{
  "bookmarks": {
    "deposit_transactions": "2020-12-01T12:12:07.000000Z",
    "gl_accounts": {
      "ASSET": "2019-11-20T00:24:06.000000Z",
      "EQUITY": "2019-07-03T15:15:43.000000Z",
      "INCOME": "2019-07-03T15:15:43.000000Z",
      "EXPENSE": "2019-07-03T15:15:43.000000Z",
      "LIABILITY": "2019-07-03T15:15:43.000000Z"
    },
    "loan_transactions": "2019-09-03T13:25:06.000000Z",
    "tasks": "2019-09-03T13:20:10.000000Z",
    "deposit_accounts": "2020-12-10T11:49:43.000000Z",
    "deposit_products": "2019-09-11T09:39:58.000000Z",
    "users": "2020-11-03T18:36:35.000000Z",
    "credit_arrangements": "2019-07-17T17:52:41.000000Z",
    "activities": "2020-11-03T18:36:35.000000Z",
    "gl_journal_entries": "2020-12-01T00:00:00.000000Z",
    "clients": "2019-09-05T16:45:57.000000Z",
    "branches": "2019-10-13T15:28:41.000000Z",
    "installments": "2019-09-03T06:25:06.000000Z",
    "centres": "2019-10-13T16:22:48.000000Z",
    "communications": "2019-07-18T01:13:39.000000Z",
    "loan_products": "2019-09-11T09:29:55.000000Z",
    "groups": "2019-08-29T15:28:40.000000Z",
    "loan_accounts": "2019-09-03T13:25:06.000000Z"
  }
}
```

4. Verified data(row counts) in DWH Target(Snowflake)
```
MAMBU_IMPORT._SDC_REJECTED | 0
MAMBU_IMPORT.ACTIVITIES | 345
MAMBU_IMPORT.BRANCHES | 2
MAMBU_IMPORT.CARDS | 1
MAMBU_IMPORT.CENTRES | 2
MAMBU_IMPORT.CLIENTS | 104
MAMBU_IMPORT.COMMUNICATIONS | 1
MAMBU_IMPORT.CREDIT_ARRANGEMENTS | 2
MAMBU_IMPORT.CUSTOM_FIELD_SETS | 21
MAMBU_IMPORT.DEPOSIT_ACCOUNTS | 3
MAMBU_IMPORT.DEPOSIT_PRODUCTS | 4
MAMBU_IMPORT.DEPOSIT_TRANSACTIONS | 39
MAMBU_IMPORT.GL_ACCOUNTS | 18
MAMBU_IMPORT.GL_JOURNAL_ENTRIES | 295
MAMBU_IMPORT.GROUPS | 3
MAMBU_IMPORT.INSTALLMENTS | 10
MAMBU_IMPORT.LOAN_ACCOUNTS | 7
MAMBU_IMPORT.LOAN_PRODUCTS | 2
MAMBU_IMPORT.LOAN_REPAYMENTS | 35
MAMBU_IMPORT.LOAN_TRANSACTIONS | 9
MAMBU_IMPORT.TASKS | 8
MAMBU_IMPORT.USERS | 3
```

5. Ran Check Tap with state from previous run
```
Checking stdin for valid Singer-formatted data
The output is valid.
It contained 192 messages for 22 streams.

     34 schema messages
     88 record messages
     70 state messages

Details by stream:
+----------------------+---------+---------+
| stream               | records | schemas |
+----------------------+---------+---------+
| branches             | 1       | 1       |
| communications       | 1       | 1       |
| centres              | 1       | 1       |
| clients              | 1       | 1       |
| credit_arrangements  | 0       | 1       |
| custom_field_sets    | 21      | 1       |
| deposit_accounts     | 3       | 1       |
| cards                | 1       | 3       |
| deposit_products     | 1       | 1       |
| deposit_transactions | 1       | 1       |
| groups               | 3       | 1       |
| loan_accounts        | 1       | 1       |
| loan_repayments      | 35      | 7       |
| loan_products        | 1       | 1       |
| loan_transactions    | 1       | 1       |
| tasks                | 1       | 1       |
| users                | 1       | 1       |
| gl_accounts          | 1       | 5       |
| gl_journal_entries   | 2       | 1       |
| activities           | 1       | 1       |
| index_rate_sources   | 0       | 1       |
| installments         | 10      | 1       |
+----------------------+---------+---------+
```

6. Ran (Incremental) Sync - Singer Target with previous state
Resulting state
```
{
  "bookmarks": {
    "branches": "2019-10-13T15:28:41.000000Z",
    "deposit_products": "2019-09-11T09:39:58.000000Z",
    "groups": "2019-08-29T15:28:40.000000Z",
    "communications": "2019-07-18T01:13:39.000000Z",
    "clients": "2019-09-05T16:45:57.000000Z",
    "loan_accounts": "2019-09-03T13:25:06.000000Z",
    "tasks": "2019-09-03T13:20:10.000000Z",
    "loan_transactions": "2019-09-03T13:25:06.000000Z",
    "deposit_accounts": "2020-12-10T11:49:43.000000Z",
    "deposit_transactions": "2020-12-01T12:12:07.000000Z",
    "centres": "2019-10-13T16:22:48.000000Z",
    "gl_journal_entries": "2020-12-01T00:00:00.000000Z",
    "loan_products": "2019-09-11T09:29:55.000000Z",
    "credit_arrangements": "2019-09-01T00:00:00Z",
    "users": "2020-11-03T18:36:35.000000Z",
    "gl_accounts": {
      "EXPENSE": "2019-09-01T00:00:00Z",
      "INCOME": "2019-09-01T00:00:00Z",
      "EQUITY": "2019-09-01T00:00:00Z",
      "ASSET": "2019-11-20T00:24:06.000000Z",
      "LIABILITY": "2019-09-01T00:00:00Z"
    },
    "installments": "2019-09-03T06:25:06.000000Z",
    "activities": "2020-11-03T18:36:35.000000Z"
  }
}
```

7. Verified data(row counts) in target DWH(Snowflake) (after incremental sync)
```
MAMBU_IMPORT._SDC_REJECTED | 0
MAMBU_IMPORT.ACTIVITIES | 345
MAMBU_IMPORT.BRANCHES | 2
MAMBU_IMPORT.CARDS | 1
MAMBU_IMPORT.CENTRES | 2
MAMBU_IMPORT.CLIENTS | 104
MAMBU_IMPORT.COMMUNICATIONS | 1
MAMBU_IMPORT.CREDIT_ARRANGEMENTS | 2
MAMBU_IMPORT.CUSTOM_FIELD_SETS | 21
MAMBU_IMPORT.DEPOSIT_ACCOUNTS | 3
MAMBU_IMPORT.DEPOSIT_PRODUCTS | 4
MAMBU_IMPORT.DEPOSIT_TRANSACTIONS | 39
MAMBU_IMPORT.GL_ACCOUNTS | 18
MAMBU_IMPORT.GL_JOURNAL_ENTRIES | 295
MAMBU_IMPORT.GROUPS | 3
MAMBU_IMPORT.INSTALLMENTS | 10
MAMBU_IMPORT.LOAN_ACCOUNTS | 7
MAMBU_IMPORT.LOAN_PRODUCTS | 2
MAMBU_IMPORT.LOAN_REPAYMENTS | 35
MAMBU_IMPORT.LOAN_TRANSACTIONS | 9
MAMBU_IMPORT.TASKS | 8
MAMBU_IMPORT.USERS | 3
```

8. Ran pylint
```
pylint tap_mambu -d missing-docstring -d logging-format-interpolation -d too-many-locals -d too-many-arguments
```

```
Your code has been rated at 9.38/10 (previous run: 9.38/10, +0.00)
```

No new errors or significant issues returned vs. previous run.
 
# Risks
There exists no data in the test data set for stream `index_rate_sources`. 
 
# Rollback steps
 - revert this branch
