### PR TITLE
Update custom field schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.3
+  * Update custom field transformations and schema for streams.
+
 ## 1.1.2
   * Added lookback window for loan transactions stream.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='1.1.2',
+      version='1.1.3',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mambu/schemas/branches.json
+++ b/tap_mambu/schemas/branches.json
@@ -1,160 +1,141 @@
 {
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "email_address": {
-      "type": ["null", "string"]
-    },
-    "addresses": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "country": {
-                "type": ["null", "string"]
-              },
-              "parent_key": {
-                "type": ["null", "string"]
-              },
-              "city": {
-                "type": ["null", "string"]
-              },
-              "latitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "postcode": {
-                "type": ["null", "string"]
-              },
-              "index_in_list": {
-                "type": ["null", "integer"]
-              },
-              "encoded_key": {
-                "type": ["null", "string"]
-              },
-              "region": {
-                "type": ["null", "string"]
-              },
-              "line2": {
-                "type": ["null", "string"]
-              },
-              "line1": {
-                "type": ["null", "string"]
-              },
-              "longitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              }
-            }
-          }
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "email_address": {
+            "type": ["null", "string"]
         },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "phone_number": {
-      "type": ["null", "string"]
-    },
-    "notes": {
-      "type": ["null", "string"]
-    },
-    "last_modified_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "name": {
-      "type": ["null", "string"]
-    },
-    "encoded_key": {
-      "type": ["null", "string"]
-    },
-    "id": {
-      "type": ["null", "string"]
-    },
-    "state": {
-      "type": ["null", "string"]
-    },
-    "creation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "branch_holidays": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "type": ["null", "string"]
-              },
-              "date": {
-                "type": ["null", "string"],
-                "format": "date"
-              },
-              "encoded_key": {
-                "type": ["null", "string"]
-              },
-              "is_anually_recurring": {
-                "type": ["null", "boolean"]
-              },
-              "creation_date": {
-                "type": ["null", "string"],
-                "format": "date-time"
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "custom_field_sets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_field_set_id": {
-                "type": ["null", "string"]
-              },
-              "custom_field_values": {
-                "anyOf": [
-                  {
+        "addresses": {
+            "anyOf": [{
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "custom_field_id": {
-                          "type": ["null", "string"]
-                        },
-                        "custom_field_value": {
-                          "type": ["null", "string"]
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "country": {
+                                "type": ["null", "string"]
+                            },
+                            "parent_key": {
+                                "type": ["null", "string"]
+                            },
+                            "city": {
+                                "type": ["null", "string"]
+                            },
+                            "latitude": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "postcode": {
+                                "type": ["null", "string"]
+                            },
+                            "index_in_list": {
+                                "type": ["null", "integer"]
+                            },
+                            "encoded_key": {
+                                "type": ["null", "string"]
+                            },
+                            "region": {
+                                "type": ["null", "string"]
+                            },
+                            "line2": {
+                                "type": ["null", "string"]
+                            },
+                            "line1": {
+                                "type": ["null", "string"]
+                            },
+                            "longitude": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            }
                         }
-                      }
                     }
-                  },
-                  {
+                },
+                {
                     "type": "null"
-                  }
-                ]
-              }
-            }
-          }
+                }
+            ]
         },
-        {
-          "type": "null"
+        "phone_number": {
+            "type": ["null", "string"]
+        },
+        "notes": {
+            "type": ["null", "string"]
+        },
+        "last_modified_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "name": {
+            "type": ["null", "string"]
+        },
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "id": {
+            "type": ["null", "string"]
+        },
+        "state": {
+            "type": ["null", "string"]
+        },
+        "creation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "branch_holidays": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "type": ["null", "string"]
+                            },
+                            "date": {
+                                "type": ["null", "string"],
+                                "format": "date"
+                            },
+                            "encoded_key": {
+                                "type": ["null", "string"]
+                            },
+                            "is_anually_recurring": {
+                                "type": ["null", "boolean"]
+                            },
+                            "creation_date": {
+                                "type": ["null", "string"],
+                                "format": "date-time"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "custom_fields": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "field_set_id": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "string"]
+                            },
+                            "value": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/tap_mambu/schemas/centres.json
+++ b/tap_mambu/schemas/centres.json
@@ -1,127 +1,109 @@
 {
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "addresses": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "country": {
-                "type": ["null", "string"]
-              },
-              "parent_key": {
-                "type": ["null", "string"]
-              },
-              "city": {
-                "type": ["null", "string"]
-              },
-              "latitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "postcode": {
-                "type": ["null", "string"]
-              },
-              "index_in_list": {
-                "type": ["null", "integer"]
-              },
-              "encoded_key": {
-                "type": ["null", "string"]
-              },
-              "region": {
-                "type": ["null", "string"]
-              },
-              "line2": {
-                "type": ["null", "string"]
-              },
-              "line1": {
-                "type": ["null", "string"]
-              },
-              "longitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "notes": {
-      "type": ["null", "string"]
-    },
-    "last_modified_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "name": {
-      "type": ["null", "string"]
-    },
-    "meeting_day": {
-      "type": ["null", "string"]
-    },
-    "encoded_key": {
-      "type": ["null", "string"]
-    },
-    "id": {
-      "type": ["null", "string"]
-    },
-    "state": {
-      "type": ["null", "string"]
-    },
-    "creation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "assigned_branch_key": {
-      "type": ["null", "string"]
-    },
-    "custom_field_sets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_field_set_id": {
-                "type": ["null", "string"]
-              },
-              "custom_field_values": {
-                "anyOf": [
-                  {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "addresses": {
+            "anyOf": [{
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "custom_field_id": {
-                          "type": ["null", "string"]
-                        },
-                        "custom_field_value": {
-                          "type": ["null", "string"]
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "country": {
+                                "type": ["null", "string"]
+                            },
+                            "parent_key": {
+                                "type": ["null", "string"]
+                            },
+                            "city": {
+                                "type": ["null", "string"]
+                            },
+                            "latitude": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "postcode": {
+                                "type": ["null", "string"]
+                            },
+                            "index_in_list": {
+                                "type": ["null", "integer"]
+                            },
+                            "encoded_key": {
+                                "type": ["null", "string"]
+                            },
+                            "region": {
+                                "type": ["null", "string"]
+                            },
+                            "line2": {
+                                "type": ["null", "string"]
+                            },
+                            "line1": {
+                                "type": ["null", "string"]
+                            },
+                            "longitude": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            }
                         }
-                      }
                     }
-                  },
-                  {
+                },
+                {
                     "type": "null"
-                  }
-                ]
-              }
-            }
-          }
+                }
+            ]
         },
-        {
-          "type": "null"
+        "notes": {
+            "type": ["null", "string"]
+        },
+        "last_modified_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "name": {
+            "type": ["null", "string"]
+        },
+        "meeting_day": {
+            "type": ["null", "string"]
+        },
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "id": {
+            "type": ["null", "string"]
+        },
+        "state": {
+            "type": ["null", "string"]
+        },
+        "creation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "assigned_branch_key": {
+            "type": ["null", "string"]
+        },
+        "custom_fields": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "field_set_id": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "string"]
+                            },
+                            "value": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/tap_mambu/schemas/clients.json
+++ b/tap_mambu/schemas/clients.json
@@ -1,220 +1,201 @@
 {
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "last_name": {
-      "type": ["null", "string"]
-    },
-    "migration_event_key": {
-      "type": ["null", "string"]
-    },
-    "preferred_language": {
-      "type": ["null", "string"]
-    },
-    "addresses": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "country": {
-                "type": ["null", "string"]
-              },
-              "parent_key": {
-                "type": ["null", "string"]
-              },
-              "city": {
-                "type": ["null", "string"]
-              },
-              "latitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "postcode": {
-                "type": ["null", "string"]
-              },
-              "index_in_list": {
-                "type": ["null", "integer"]
-              },
-              "encoded_key": {
-                "type": ["null", "string"]
-              },
-              "region": {
-                "type": ["null", "string"]
-              },
-              "line2": {
-                "type": ["null", "string"]
-              },
-              "line1": {
-                "type": ["null", "string"]
-              },
-              "longitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              }
-            }
-          }
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "last_name": {
+            "type": ["null", "string"]
         },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "notes": {
-      "type": ["null", "string"]
-    },
-    "gender": {
-      "type": ["null", "string"]
-    },
-    "group_loan_cycle": {
-      "type": ["null", "integer"]
-    },
-    "email_address": {
-      "type": ["null", "string"]
-    },
-    "encoded_key": {
-      "type": ["null", "string"]
-    },
-    "id": {
-      "type": ["null", "string"]
-    },
-    "state": {
-      "type": ["null", "string"]
-    },
-    "assigned_user_key": {
-      "type": ["null", "string"]
-    },
-    "client_role_key": {
-      "type": ["null", "string"]
-    },
-    "last_modified_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "home_phone": {
-      "type": ["null", "string"]
-    },
-    "creation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "birth_date": {
-      "type": ["null", "string"],
-      "format": "date"
-    },
-    "assigned_centre_key": {
-      "type": ["null", "string"]
-    },
-    "approved_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "first_name": {
-      "type": ["null", "string"]
-    },
-    "id_documents": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "identification_document_template_key": {
-                "type": ["null", "string"]
-              },
-              "issuing_authority": {
-                "type": ["null", "string"]
-              },
-              "client_key": {
-                "type": ["null", "string"]
-              },
-              "document_type": {
-                "type": ["null", "string"]
-              },
-              "index_in_list": {
-                "type": ["null", "integer"]
-              },
-              "valid_until": {
-                "type": ["null", "string"],
-                "format": "date"
-              },
-              "encoded_key": {
-                "type": ["null", "string"]
-              },
-              "document_id": {
-                "type": ["null", "string"]
-              }
-            }
-          }
+        "migration_event_key": {
+            "type": ["null", "string"]
         },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "profile_picture_key": {
-      "type": ["null", "string"]
-    },
-    "profile_signature_key": {
-      "type": ["null", "string"]
-    },
-    "mobile_phone": {
-      "type": ["null", "string"]
-    },
-    "closed_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "middle_name": {
-      "type": ["null", "string"]
-    },
-    "activation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "custom_field_sets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_field_set_id": {
-                "type": ["null", "string"]
-              },
-              "custom_field_values": {
-                "anyOf": [
-                  {
+        "preferred_language": {
+            "type": ["null", "string"]
+        },
+        "addresses": {
+            "anyOf": [{
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "custom_field_id": {
-                          "type": ["null", "string"]
-                        },
-                        "custom_field_value": {
-                          "type": ["null", "string"]
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "country": {
+                                "type": ["null", "string"]
+                            },
+                            "parent_key": {
+                                "type": ["null", "string"]
+                            },
+                            "city": {
+                                "type": ["null", "string"]
+                            },
+                            "latitude": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "postcode": {
+                                "type": ["null", "string"]
+                            },
+                            "index_in_list": {
+                                "type": ["null", "integer"]
+                            },
+                            "encoded_key": {
+                                "type": ["null", "string"]
+                            },
+                            "region": {
+                                "type": ["null", "string"]
+                            },
+                            "line2": {
+                                "type": ["null", "string"]
+                            },
+                            "line1": {
+                                "type": ["null", "string"]
+                            },
+                            "longitude": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            }
                         }
-                      }
                     }
-                  },
-                  {
+                },
+                {
                     "type": "null"
-                  }
-                ]
-              }
-            }
-          }
+                }
+            ]
         },
-        {
-          "type": "null"
+        "notes": {
+            "type": ["null", "string"]
+        },
+        "gender": {
+            "type": ["null", "string"]
+        },
+        "group_loan_cycle": {
+            "type": ["null", "integer"]
+        },
+        "email_address": {
+            "type": ["null", "string"]
+        },
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "id": {
+            "type": ["null", "string"]
+        },
+        "state": {
+            "type": ["null", "string"]
+        },
+        "assigned_user_key": {
+            "type": ["null", "string"]
+        },
+        "client_role_key": {
+            "type": ["null", "string"]
+        },
+        "last_modified_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "home_phone": {
+            "type": ["null", "string"]
+        },
+        "creation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "birth_date": {
+            "type": ["null", "string"],
+            "format": "date"
+        },
+        "assigned_centre_key": {
+            "type": ["null", "string"]
+        },
+        "approved_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "first_name": {
+            "type": ["null", "string"]
+        },
+        "id_documents": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "identification_document_template_key": {
+                                "type": ["null", "string"]
+                            },
+                            "issuing_authority": {
+                                "type": ["null", "string"]
+                            },
+                            "client_key": {
+                                "type": ["null", "string"]
+                            },
+                            "document_type": {
+                                "type": ["null", "string"]
+                            },
+                            "index_in_list": {
+                                "type": ["null", "integer"]
+                            },
+                            "valid_until": {
+                                "type": ["null", "string"],
+                                "format": "date"
+                            },
+                            "encoded_key": {
+                                "type": ["null", "string"]
+                            },
+                            "document_id": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "profile_picture_key": {
+            "type": ["null", "string"]
+        },
+        "profile_signature_key": {
+            "type": ["null", "string"]
+        },
+        "mobile_phone": {
+            "type": ["null", "string"]
+        },
+        "closed_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "middle_name": {
+            "type": ["null", "string"]
+        },
+        "activation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "custom_fields": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "field_set_id": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "string"]
+                            },
+                            "value": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/tap_mambu/schemas/communications.json
+++ b/tap_mambu/schemas/communications.json
@@ -1,112 +1,95 @@
 {
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "sender_key": {
-      "type": ["null", "string"]
-    },
-    "send_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "num_retries": {
-      "type": ["null", "integer"]
-    },
-    "subject": {
-      "type": ["null", "string"]
-    },
-    "loan_account_key": {
-      "type": ["null", "string"]
-    },
-    "destination": {
-      "type": ["null", "string"]
-    },
-    "deposit_account_key": {
-      "type": ["null", "string"]
-    },
-    "failure_cause": {
-      "type": ["null", "string"]
-    },
-    "creation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "type": {
-      "type": ["null", "string"]
-    },
-    "body": {
-      "type": ["null", "string"]
-    },
-    "reference_id": {
-      "type": ["null", "string"]
-    },
-    "group_key": {
-      "type": ["null", "string"]
-    },
-    "user_key": {
-      "type": ["null", "string"]
-    },
-    "repayment_key": {
-      "type": ["null", "string"]
-    },
-    "client_key": {
-      "type": ["null", "string"]
-    },
-    "failure_reason": {
-      "type": ["null", "string"]
-    },
-    "encoded_key": {
-      "type": ["null", "string"]
-    },
-    "state": {
-      "type": ["null", "string"]
-    },
-    "event": {
-      "type": ["null", "string"]
-    },
-    "template_key": {
-      "type": ["null", "string"]
-    },
-    "custom_field_sets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_field_set_id": {
-                "type": ["null", "string"]
-              },
-              "custom_field_values": {
-                "anyOf": [
-                  {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "sender_key": {
+            "type": ["null", "string"]
+        },
+        "send_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "num_retries": {
+            "type": ["null", "integer"]
+        },
+        "subject": {
+            "type": ["null", "string"]
+        },
+        "loan_account_key": {
+            "type": ["null", "string"]
+        },
+        "destination": {
+            "type": ["null", "string"]
+        },
+        "deposit_account_key": {
+            "type": ["null", "string"]
+        },
+        "failure_cause": {
+            "type": ["null", "string"]
+        },
+        "creation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "type": {
+            "type": ["null", "string"]
+        },
+        "body": {
+            "type": ["null", "string"]
+        },
+        "reference_id": {
+            "type": ["null", "string"]
+        },
+        "group_key": {
+            "type": ["null", "string"]
+        },
+        "user_key": {
+            "type": ["null", "string"]
+        },
+        "repayment_key": {
+            "type": ["null", "string"]
+        },
+        "client_key": {
+            "type": ["null", "string"]
+        },
+        "failure_reason": {
+            "type": ["null", "string"]
+        },
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "state": {
+            "type": ["null", "string"]
+        },
+        "event": {
+            "type": ["null", "string"]
+        },
+        "template_key": {
+            "type": ["null", "string"]
+        },
+        "custom_fields": {
+            "anyOf": [{
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "custom_field_id": {
-                          "type": ["null", "string"]
-                        },
-                        "custom_field_value": {
-                          "type": ["null", "string"]
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "field_set_id": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "string"]
+                            },
+                            "value": {
+                                "type": ["null", "string"]
+                            }
                         }
-                      }
                     }
-                  },
-                  {
+                },
+                {
                     "type": "null"
-                  }
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/tap_mambu/schemas/credit_arrangements.json
+++ b/tap_mambu/schemas/credit_arrangements.json
@@ -1,100 +1,83 @@
 {
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "available_credit_amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
-    },
-    "amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
-    },
-    "notes": {
-      "type": ["null", "string"]
-    },
-    "last_modified_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "holder_key": {
-      "type": ["null", "string"]
-    },
-    "consumed_credit_amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
-    },
-    "creation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "approved_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "sub_state": {
-      "type": ["null", "string"]
-    },
-    "encoded_key": {
-      "type": ["null", "string"]
-    },
-    "expire_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "id": {
-      "type": ["null", "string"]
-    },
-    "state": {
-      "type": ["null", "string"]
-    },
-    "holder_type": {
-      "type": ["null", "string"]
-    },
-    "start_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "custom_field_sets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_field_set_id": {
-                "type": ["null", "string"]
-              },
-              "custom_field_values": {
-                "anyOf": [
-                  {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "available_credit_amount": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-10
+        },
+        "amount": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-10
+        },
+        "notes": {
+            "type": ["null", "string"]
+        },
+        "last_modified_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "holder_key": {
+            "type": ["null", "string"]
+        },
+        "consumed_credit_amount": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-10
+        },
+        "creation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "approved_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "sub_state": {
+            "type": ["null", "string"]
+        },
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "expire_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "id": {
+            "type": ["null", "string"]
+        },
+        "state": {
+            "type": ["null", "string"]
+        },
+        "holder_type": {
+            "type": ["null", "string"]
+        },
+        "start_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "custom_fields": {
+            "anyOf": [{
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "custom_field_id": {
-                          "type": ["null", "string"]
-                        },
-                        "custom_field_value": {
-                          "type": ["null", "string"]
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "field_set_id": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "string"]
+                            },
+                            "value": {
+                                "type": ["null", "string"]
+                            }
                         }
-                      }
                     }
-                  },
-                  {
+                },
+                {
                     "type": "null"
-                  }
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/tap_mambu/schemas/deposit_accounts.json
+++ b/tap_mambu/schemas/deposit_accounts.json
@@ -1,421 +1,400 @@
 {
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "account_state": {
-      "type": ["null", "string"]
-    },
-    "migration_event_key": {
-      "type": ["null", "string"]
-    },
-    "notes": {
-      "type": ["null", "string"]
-    },
-    "last_sent_to_arrears_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "assigned_branch_key": {
-      "type": ["null", "string"]
-    },
-    "last_overdraft_interest_review_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "last_interest_stored_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "interest_settings": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "interest_rate_settings": {
-          "type": ["null", "object"],
-          "additionalProperties": false,
-          "properties": {
-            "interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
-              "minimum": -1000000000000000,
-              "maximum": 1000000000000000
-            },
-            "interest_rate_tiers": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                      "ending_balance": {
-                        "type": ["null", "number"],
-                        "multipleOf": 1e-10
-                      },
-                      "interest_rate": {
-                        "type": ["null", "number"],
-                        "multipleOf": 1e-20,
-                        "minimum": -1000000000000000,
-                        "maximum": 1000000000000000
-                      },
-                      "encoded_key": {
-                        "type": ["null", "string"]
-                      },
-                      "ending_day": {
-                        "type": ["null", "integer"]
-                      }
-                    }
-                  }
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "interest_charge_frequency": {
-              "type": ["null", "string"]
-            },
-            "encoded_key": {
-              "type": ["null", "string"]
-            },
-            "interest_charge_frequency_count": {
-              "type": ["null", "integer"]
-            },
-            "interest_rate_terms": {
-              "type": ["null", "string"]
-            }
-          }
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "account_state": {
+            "type": ["null", "string"]
         },
-        "interest_payment_settings": {
-          "type": ["null", "object"],
-          "additionalProperties": false,
-          "properties": {
-            "interest_payment_dates": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                      "month": {
-                        "type": ["null", "integer"]
-                      },
-                      "day": {
-                        "type": ["null", "integer"]
-                      }
-                    }
-                  }
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "interest_payment_point": {
-              "type": ["null", "string"]
-            }
-          }
-        }
-      }
-    },
-    "balances": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "overdraft_interest_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+        "migration_event_key": {
+            "type": ["null", "string"]
         },
-        "total_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+        "notes": {
+            "type": ["null", "string"]
         },
-        "locked_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+        "last_sent_to_arrears_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
         },
-        "technical_overdraft_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+        "assigned_branch_key": {
+            "type": ["null", "string"]
         },
-        "overdraft_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+        "last_overdraft_interest_review_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
         },
-        "hold_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+        "last_interest_stored_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
         },
-        "technical_overdraft_interest_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "fees_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "available_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        }
-      }
-    },
-    "credit_arrangement_key": {
-      "type": ["null", "string"]
-    },
-    "maturity_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "encoded_key": {
-      "type": ["null", "string"]
-    },
-    "id": {
-      "type": ["null", "string"]
-    },
-    "overdraft_settings": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "allowed_overdraft": {
-          "type": ["null", "boolean"]
-        },
-        "overdraft_limit": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "overdraft_expiry_date": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        }
-      }
-    },
-    "last_account_appraisal_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "withholding_tax_source_key": {
-      "type": ["null", "string"]
-    },
-    "assigned_user_key": {
-      "type": ["null", "string"]
-    },
-    "overdraft_interest_settings": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "interest_rate_settings": {
-          "type": ["null", "object"],
-          "additionalProperties": false,
-          "properties": {
-            "interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
-              "minimum": -1000000000000000,
-              "maximum": 1000000000000000
-            },
-            "interest_spread": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
-              "minimum": -1000000000000000,
-              "maximum": 1000000000000000
-            },
-            "interest_rate_review_unit": {
-              "type": ["null", "string"]
-            },
-            "interest_rate_source": {
-              "type": ["null", "string"]
-            },
-            "interest_rate_review_count": {
-              "type": ["null", "integer"]
-            },
-            "interest_rate_tiers": {
-              "anyOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                      "ending_balance": {
-                        "type": ["null", "number"],
-                        "multipleOf": 1e-10
-                      },
-                      "interest_rate": {
-                        "type": ["null", "number"],
-                        "multipleOf": 1e-20,
-                        "minimum": -1000000000000000,
-                        "maximum": 1000000000000000
-                      },
-                      "encoded_key": {
-                        "type": ["null", "string"]
-                      },
-                      "ending_day": {
-                        "type": ["null", "integer"]
-                      }
-                    }
-                  }
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "interest_charge_frequency": {
-              "type": ["null", "string"]
-            },
-            "encoded_key": {
-              "type": ["null", "string"]
-            },
-            "interest_charge_frequency_count": {
-              "type": ["null", "integer"]
-            },
-            "interest_rate_terms": {
-              "type": ["null", "string"]
-            }
-          }
-        }
-      }
-    },
-    "last_modified_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "account_type": {
-      "type": ["null", "string"]
-    },
-    "locked_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "creation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "last_interest_calculation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "assigned_centre_key": {
-      "type": ["null", "string"]
-    },
-    "approved_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "closed_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "accrued_amounts": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "overdraft_interest_accrued": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "interest_accrued": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "technical_overdraft_interest_accrued": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        }
-      }
-    },
-    "name": {
-      "type": ["null", "string"]
-    },
-    "account_holder_key": {
-      "type": ["null", "string"]
-    },
-    "product_type_key": {
-      "type": ["null", "string"]
-    },
-    "activation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "internal_controls": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "recommended_deposit_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "target_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "max_withdrawal_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        }
-      }
-    },
-    "currency_code": {
-      "type": ["null", "string"]
-    },
-    "account_holder_type": {
-      "type": ["null", "string"]
-    },
-    "linked_settlement_account_keys": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "custom_field_sets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
+        "interest_settings": {
+            "type": ["null", "object"],
             "additionalProperties": false,
             "properties": {
-              "custom_field_set_id": {
-                "type": ["null", "string"]
-              },
-              "custom_field_values": {
-                "anyOf": [
-                  {
+                "interest_rate_settings": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "interest_rate": {
+                            "type": ["null", "number"],
+                            "multipleOf": 1e-20,
+                            "minimum": -1000000000000000,
+                            "maximum": 1000000000000000
+                        },
+                        "interest_rate_tiers": {
+                            "anyOf": [{
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "ending_balance": {
+                                                "type": ["null", "number"],
+                                                "multipleOf": 1e-10
+                                            },
+                                            "interest_rate": {
+                                                "type": ["null", "number"],
+                                                "multipleOf": 1e-20,
+                                                "minimum": -1000000000000000,
+                                                "maximum": 1000000000000000
+                                            },
+                                            "encoded_key": {
+                                                "type": ["null", "string"]
+                                            },
+                                            "ending_day": {
+                                                "type": ["null", "integer"]
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "interest_charge_frequency": {
+                            "type": ["null", "string"]
+                        },
+                        "encoded_key": {
+                            "type": ["null", "string"]
+                        },
+                        "interest_charge_frequency_count": {
+                            "type": ["null", "integer"]
+                        },
+                        "interest_rate_terms": {
+                            "type": ["null", "string"]
+                        }
+                    }
+                },
+                "interest_payment_settings": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "interest_payment_dates": {
+                            "anyOf": [{
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "month": {
+                                                "type": ["null", "integer"]
+                                            },
+                                            "day": {
+                                                "type": ["null", "integer"]
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "interest_payment_point": {
+                            "type": ["null", "string"]
+                        }
+                    }
+                }
+            }
+        },
+        "balances": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "overdraft_interest_due": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "total_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "locked_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "technical_overdraft_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "overdraft_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "hold_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "technical_overdraft_interest_due": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "fees_due": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "available_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                }
+            }
+        },
+        "credit_arrangement_key": {
+            "type": ["null", "string"]
+        },
+        "maturity_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "id": {
+            "type": ["null", "string"]
+        },
+        "overdraft_settings": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "allowed_overdraft": {
+                    "type": ["null", "boolean"]
+                },
+                "overdraft_limit": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "overdraft_expiry_date": {
+                    "type": ["null", "string"],
+                    "format": "date-time"
+                }
+            }
+        },
+        "last_account_appraisal_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "withholding_tax_source_key": {
+            "type": ["null", "string"]
+        },
+        "assigned_user_key": {
+            "type": ["null", "string"]
+        },
+        "overdraft_interest_settings": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "interest_rate_settings": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "interest_rate": {
+                            "type": ["null", "number"],
+                            "multipleOf": 1e-20,
+                            "minimum": -1000000000000000,
+                            "maximum": 1000000000000000
+                        },
+                        "interest_spread": {
+                            "type": ["null", "number"],
+                            "multipleOf": 1e-20,
+                            "minimum": -1000000000000000,
+                            "maximum": 1000000000000000
+                        },
+                        "interest_rate_review_unit": {
+                            "type": ["null", "string"]
+                        },
+                        "interest_rate_source": {
+                            "type": ["null", "string"]
+                        },
+                        "interest_rate_review_count": {
+                            "type": ["null", "integer"]
+                        },
+                        "interest_rate_tiers": {
+                            "anyOf": [{
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "ending_balance": {
+                                                "type": ["null", "number"],
+                                                "multipleOf": 1e-10
+                                            },
+                                            "interest_rate": {
+                                                "type": ["null", "number"],
+                                                "multipleOf": 1e-20,
+                                                "minimum": -1000000000000000,
+                                                "maximum": 1000000000000000
+                                            },
+                                            "encoded_key": {
+                                                "type": ["null", "string"]
+                                            },
+                                            "ending_day": {
+                                                "type": ["null", "integer"]
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        },
+                        "interest_charge_frequency": {
+                            "type": ["null", "string"]
+                        },
+                        "encoded_key": {
+                            "type": ["null", "string"]
+                        },
+                        "interest_charge_frequency_count": {
+                            "type": ["null", "integer"]
+                        },
+                        "interest_rate_terms": {
+                            "type": ["null", "string"]
+                        }
+                    }
+                }
+            }
+        },
+        "last_modified_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "account_type": {
+            "type": ["null", "string"]
+        },
+        "locked_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "creation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "last_interest_calculation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "assigned_centre_key": {
+            "type": ["null", "string"]
+        },
+        "approved_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "closed_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "accrued_amounts": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "overdraft_interest_accrued": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "interest_accrued": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "technical_overdraft_interest_accrued": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                }
+            }
+        },
+        "name": {
+            "type": ["null", "string"]
+        },
+        "account_holder_key": {
+            "type": ["null", "string"]
+        },
+        "product_type_key": {
+            "type": ["null", "string"]
+        },
+        "activation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "internal_controls": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "recommended_deposit_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "target_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "max_withdrawal_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                }
+            }
+        },
+        "currency_code": {
+            "type": ["null", "string"]
+        },
+        "account_holder_type": {
+            "type": ["null", "string"]
+        },
+        "linked_settlement_account_keys": {
+            "anyOf": [{
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "custom_field_id": {
-                          "type": ["null", "string"]
-                        },
-                        "custom_field_value": {
-                          "type": ["null", "string"]
-                        }
-                      }
+                        "type": "string"
                     }
-                  },
-                  {
+                },
+                {
                     "type": "null"
-                  }
-                ]
-              }
-            }
-          }
+                }
+            ]
         },
-        {
-          "type": "null"
+        "custom_fields": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "field_set_id": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "string"]
+                            },
+                            "value": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/tap_mambu/schemas/deposit_transactions.json
+++ b/tap_mambu/schemas/deposit_transactions.json
@@ -1,331 +1,313 @@
 {
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "migration_event_key": {
-      "type": ["null", "string"]
-    },
-    "transaction_details": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "transaction_channel_id": {
-          "type": ["null", "string"]
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "migration_event_key": {
+            "type": ["null", "string"]
         },
-        "transaction_channel_key": {
-          "type": ["null", "string"]
-        }
-      }
-    },
-    "fees": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
+        "transaction_details": {
+            "type": ["null", "object"],
             "additionalProperties": false,
             "properties": {
-              "name": {
-                "type": ["null", "string"]
-              },
-              "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "trigger": {
-                "type": ["null", "string"]
-              },
-              "tax_amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "predefined_fee_key": {
-                "type": ["null", "string"]
-              }
+                "transaction_channel_id": {
+                    "type": ["null", "string"]
+                },
+                "transaction_channel_key": {
+                    "type": ["null", "string"]
+                }
             }
-          }
         },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "notes": {
-      "type": ["null", "string"]
-    },
-    "affected_amounts": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "fees_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "overdraft_interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "overdraft_fees_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "fraction_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "technical_overdraft_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "overdraft_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "technical_overdraft_interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "funds_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        }
-      }
-    },
-    "card_transaction": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "external_reference_id": {
-          "type": ["null", "string"]
-        },
-        "amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "advice": {
-          "type": ["null", "boolean"]
-        },
-        "external_authorization_reference_id": {
-          "type": ["null", "string"]
-        },
-
-        "card_acceptor": {
-          "type": ["null", "object"],
-          "additionalProperties": false,
-          "properties": {
-            "zip": {
-              "type": ["null", "string"]
-            },
-            "country": {
-              "type": ["null", "string"]
-            },
-            "city": {
-              "type": ["null", "string"]
-            },
-            "name": {
-              "type": ["null", "string"]
-            },
-            "state": {
-              "type": ["null", "string"]
-            },
-            "mcc": {
-              "type": ["null", "integer"]
-            }
-          }
-        },
-        "encoded_key": {
-          "type": ["null", "string"]
-        },
-        "user_transaction_time": {
-          "type": ["null", "string"]
-        },
-        "currency_code": {
-          "type": ["null", "string"]
-        },
-        "card_token": {
-          "type": ["null", "string"]
-        }
-      }
-    },
-    "taxes": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "tax_rate": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20,
-          "minimum": -1000000000000000,
-          "maximum": 1000000000000000
-        }
-      }
-    },
-    "till_key": {
-      "type": ["null", "string"]
-    },
-    "adjustment_transaction_key": {
-      "type": ["null", "string"]
-    },
-    "type": {
-      "type": ["null", "string"]
-    },
-    "branch_key": {
-      "type": ["null", "string"]
-    },
-    "terms": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "interest_settings": {
-          "type": ["null", "object"],
-          "additionalProperties": false,
-          "properties": {
-            "interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
-              "minimum": -1000000000000000,
-              "maximum": 1000000000000000
-            }
-          }
-        },
-        "overdraft_settings": {
-          "type": ["null", "object"],
-          "additionalProperties": false,
-          "properties": {
-            "overdraft_limit": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-10
-            }
-          }
-        },
-        "overdraft_interest_settings": {
-          "type": ["null", "object"],
-          "additionalProperties": false,
-          "properties": {
-            "interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
-              "minimum": -1000000000000000,
-              "maximum": 1000000000000000
-            },
-            "index_interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
-              "minimum": -1000000000000000,
-              "maximum": 1000000000000000
-            }
-          }
-        }
-      }
-    },
-    "transfer_details": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "linked_loan_transaction_key": {
-          "type": ["null", "string"]
-        },
-        "linked_deposit_transaction_key": {
-          "type": ["null", "string"]
-        }
-      }
-    },
-    "encoded_key": {
-      "type": ["null", "string"]
-    },
-    "id": {
-      "type": ["null", "string"]
-    },
-    "original_transaction_key": {
-      "type": ["null", "string"]
-    },
-    "amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
-    },
-    "centre_key": {
-      "type": ["null", "string"]
-    },
-    "external_id": {
-      "type": ["null", "string"]
-    },
-    "value_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "creation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "user_key": {
-      "type": ["null", "string"]
-    },
-    "parent_account_key": {
-      "type": ["null", "string"]
-    },
-    "linked_loan_transaction_key": {
-      "type": ["null", "string"]
-    },
-    "account_balances": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "total_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        }
-      }
-    },
-    "booking_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "currency_code": {
-      "type": ["null", "string"]
-    },
-    "custom_field_sets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_field_set_id": {
-                "type": ["null", "string"]
-              },
-              "custom_field_values": {
-                "anyOf": [
-                  {
+        "fees": {
+            "anyOf": [{
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "custom_field_id": {
-                          "type": ["null", "string"]
-                        },
-                        "custom_field_value": {
-                          "type": ["null", "string"]
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "type": ["null", "string"]
+                            },
+                            "amount": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "trigger": {
+                                "type": ["null", "string"]
+                            },
+                            "tax_amount": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "predefined_fee_key": {
+                                "type": ["null", "string"]
+                            }
                         }
-                      }
                     }
-                  },
-                  {
+                },
+                {
                     "type": "null"
-                  }
-                ]
-              }
-            }
-          }
+                }
+            ]
         },
-        {
-          "type": "null"
+        "notes": {
+            "type": ["null", "string"]
+        },
+        "affected_amounts": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "fees_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "overdraft_interest_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "overdraft_fees_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "fraction_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "technical_overdraft_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "overdraft_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "interest_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "technical_overdraft_interest_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "funds_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                }
+            }
+        },
+        "card_transaction": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "external_reference_id": {
+                    "type": ["null", "string"]
+                },
+                "amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "advice": {
+                    "type": ["null", "boolean"]
+                },
+                "external_authorization_reference_id": {
+                    "type": ["null", "string"]
+                },
+
+                "card_acceptor": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "zip": {
+                            "type": ["null", "string"]
+                        },
+                        "country": {
+                            "type": ["null", "string"]
+                        },
+                        "city": {
+                            "type": ["null", "string"]
+                        },
+                        "name": {
+                            "type": ["null", "string"]
+                        },
+                        "state": {
+                            "type": ["null", "string"]
+                        },
+                        "mcc": {
+                            "type": ["null", "integer"]
+                        }
+                    }
+                },
+                "encoded_key": {
+                    "type": ["null", "string"]
+                },
+                "user_transaction_time": {
+                    "type": ["null", "string"]
+                },
+                "currency_code": {
+                    "type": ["null", "string"]
+                },
+                "card_token": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "taxes": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "tax_rate": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-20,
+                    "minimum": -1000000000000000,
+                    "maximum": 1000000000000000
+                }
+            }
+        },
+        "till_key": {
+            "type": ["null", "string"]
+        },
+        "adjustment_transaction_key": {
+            "type": ["null", "string"]
+        },
+        "type": {
+            "type": ["null", "string"]
+        },
+        "branch_key": {
+            "type": ["null", "string"]
+        },
+        "terms": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "interest_settings": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "interest_rate": {
+                            "type": ["null", "number"],
+                            "multipleOf": 1e-20,
+                            "minimum": -1000000000000000,
+                            "maximum": 1000000000000000
+                        }
+                    }
+                },
+                "overdraft_settings": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "overdraft_limit": {
+                            "type": ["null", "number"],
+                            "multipleOf": 1e-10
+                        }
+                    }
+                },
+                "overdraft_interest_settings": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "interest_rate": {
+                            "type": ["null", "number"],
+                            "multipleOf": 1e-20,
+                            "minimum": -1000000000000000,
+                            "maximum": 1000000000000000
+                        },
+                        "index_interest_rate": {
+                            "type": ["null", "number"],
+                            "multipleOf": 1e-20,
+                            "minimum": -1000000000000000,
+                            "maximum": 1000000000000000
+                        }
+                    }
+                }
+            }
+        },
+        "transfer_details": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "linked_loan_transaction_key": {
+                    "type": ["null", "string"]
+                },
+                "linked_deposit_transaction_key": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "id": {
+            "type": ["null", "string"]
+        },
+        "original_transaction_key": {
+            "type": ["null", "string"]
+        },
+        "amount": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-10
+        },
+        "centre_key": {
+            "type": ["null", "string"]
+        },
+        "external_id": {
+            "type": ["null", "string"]
+        },
+        "value_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "creation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "user_key": {
+            "type": ["null", "string"]
+        },
+        "parent_account_key": {
+            "type": ["null", "string"]
+        },
+        "linked_loan_transaction_key": {
+            "type": ["null", "string"]
+        },
+        "account_balances": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "total_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                }
+            }
+        },
+        "booking_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "currency_code": {
+            "type": ["null", "string"]
+        },
+        "custom_fields": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "field_set_id": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "string"]
+                            },
+                            "value": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/tap_mambu/schemas/groups.json
+++ b/tap_mambu/schemas/groups.json
@@ -1,192 +1,172 @@
 {
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "group_members": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "client_key": {
-                "type": ["null", "string"]
-              },
-              "roles": {
-                "anyOf": [
-                  {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "group_members": {
+            "anyOf": [{
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "role_name": {
-                          "type": ["null", "string"]
-                        },
-                        "encoded_key": {
-                          "type": ["null", "string"]
-                        },
-                        "group_role_name_key": {
-                          "type": ["null", "string"]
-                        }                        
-                      }
-                    }
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "migration_event_key": {
-      "type": ["null", "string"]
-    },
-    "preferred_language": {
-      "type": ["null", "string"]
-    },
-    "addresses": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "country": {
-                "type": ["null", "string"]
-              },
-              "parent_key": {
-                "type": ["null", "string"]
-              },
-              "city": {
-                "type": ["null", "string"]
-              },
-              "latitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "postcode": {
-                "type": ["null", "string"]
-              },
-              "index_in_list": {
-                "type": ["null", "integer"]
-              },
-              "encoded_key": {
-                "type": ["null", "string"]
-              },
-              "region": {
-                "type": ["null", "string"]
-              },
-              "line2": {
-                "type": ["null", "string"]
-              },
-              "line1": {
-                "type": ["null", "string"]
-              },
-              "longitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "notes": {
-      "type": ["null", "string"]
-    },
-    "last_modified_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "home_phone": {
-      "type": ["null", "string"]
-    },
-    "creation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "assigned_branch_key": {
-      "type": ["null", "string"]
-    },
-    "loan_cycle": {
-      "type": ["null", "string"]
-    },
-    "assigned_centre_key": {
-      "type": ["null", "string"]
-    },
-    "group_name": {
-      "type": ["null", "string"]
-    },
-    "email_address": {
-      "type": ["null", "string"]
-    },
-    "mobile_phone": {
-      "type": ["null", "string"]
-    },
-    "group_role_key": {
-      "type": ["null", "string"]
-    },
-    "encoded_key": {
-      "type": ["null", "string"]
-    },
-    "id": {
-      "type": ["null", "string"]
-    },
-    "assigned_user_key": {
-      "type": ["null", "string"]
-    },
-    "custom_field_sets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_field_set_id": {
-                "type": ["null", "string"]
-              },
-              "custom_field_values": {
-                "anyOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "custom_field_id": {
-                          "type": ["null", "string"]
-                        },
-                        "custom_field_value": {
-                          "type": ["null", "string"]
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "client_key": {
+                                "type": ["null", "string"]
+                            },
+                            "roles": {
+                                "anyOf": [{
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "role_name": {
+                                                    "type": ["null", "string"]
+                                                },
+                                                "encoded_key": {
+                                                    "type": ["null", "string"]
+                                                },
+                                                "group_role_name_key": {
+                                                    "type": ["null", "string"]
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
+                            }
                         }
-                      }
                     }
-                  },
-                  {
+                },
+                {
                     "type": "null"
-                  }
-                ]
-              }
-            }
-          }
+                }
+            ]
         },
-        {
-          "type": "null"
+        "migration_event_key": {
+            "type": ["null", "string"]
+        },
+        "preferred_language": {
+            "type": ["null", "string"]
+        },
+        "addresses": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "country": {
+                                "type": ["null", "string"]
+                            },
+                            "parent_key": {
+                                "type": ["null", "string"]
+                            },
+                            "city": {
+                                "type": ["null", "string"]
+                            },
+                            "latitude": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "postcode": {
+                                "type": ["null", "string"]
+                            },
+                            "index_in_list": {
+                                "type": ["null", "integer"]
+                            },
+                            "encoded_key": {
+                                "type": ["null", "string"]
+                            },
+                            "region": {
+                                "type": ["null", "string"]
+                            },
+                            "line2": {
+                                "type": ["null", "string"]
+                            },
+                            "line1": {
+                                "type": ["null", "string"]
+                            },
+                            "longitude": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "notes": {
+            "type": ["null", "string"]
+        },
+        "last_modified_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "home_phone": {
+            "type": ["null", "string"]
+        },
+        "creation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "assigned_branch_key": {
+            "type": ["null", "string"]
+        },
+        "loan_cycle": {
+            "type": ["null", "string"]
+        },
+        "assigned_centre_key": {
+            "type": ["null", "string"]
+        },
+        "group_name": {
+            "type": ["null", "string"]
+        },
+        "email_address": {
+            "type": ["null", "string"]
+        },
+        "mobile_phone": {
+            "type": ["null", "string"]
+        },
+        "group_role_key": {
+            "type": ["null", "string"]
+        },
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "id": {
+            "type": ["null", "string"]
+        },
+        "assigned_user_key": {
+            "type": ["null", "string"]
+        },
+        "custom_fields": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "field_set_id": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "string"]
+                            },
+                            "value": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/tap_mambu/schemas/loan_accounts.json
+++ b/tap_mambu/schemas/loan_accounts.json
@@ -1,716 +1,691 @@
 {
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "account_state": {
-      "type": ["null", "string"]
-    },
-    "prepayment_settings": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "elements_recalculation_method": {
-          "type": ["null", "string"]
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "account_state": {
+            "type": ["null", "string"]
         },
-        "principal-paid_installment_status": {
-          "type": ["null", "string"]
-        },
-        "prepayment_recalculation_method": {
-          "type": ["null", "string"]
-        },
-        "apply_interest_on_prepayment_method": {
-          "type": ["null", "string"]
-        }
-      }
-    },
-    "migration_event_key": {
-      "type": ["null", "string"]
-    },
-    "last_set_to_arrears_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "notes": {
-      "type": ["null", "string"]
-    },
-    "disbursement_details": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "transaction_details": {
-          "type": ["null", "object"],
-          "additionalProperties": false,
-          "properties": {
-            "encoded_key": {
-              "type": ["null", "string"]
-            },
-            "internal_transfer": {
-              "type": ["null", "boolean"]
-            },
-            "transaction_channel_key": {
-              "type": ["null", "string"]
-            },
-            "transaction_channel_id": {
-              "type": ["null", "string"]
-            },
-            "target_deposit_account_key": {
-              "type": ["null", "string"]
-            }
-          }
-        },
-        "expected_disbursement_date": {
-          "type": ["null", "string"],
-          "format": "date-time"
-        },
-        "fees": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "predefined_fee_encoded_key": {
+        "prepayment_settings": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "elements_recalculation_method": {
                     "type": ["null", "string"]
-                  },
-                  "encoded_key": {
+                },
+                "principal-paid_installment_status": {
                     "type": ["null", "string"]
-                  },
-                  "amount": {
-                    "type": ["null", "number"],
-                    "multipleOf": 1e-10
-                  }
+                },
+                "prepayment_recalculation_method": {
+                    "type": ["null", "string"]
+                },
+                "apply_interest_on_prepayment_method": {
+                    "type": ["null", "string"]
                 }
-              }
-            },
-            {
-              "type": "null"
             }
-          ]
         },
-        "first_repayment_date": {
-          "type": ["null", "string"],
-          "format": "date-time"
+        "migration_event_key": {
+            "type": ["null", "string"]
         },
-        "disbursement_date": {
-          "type": ["null", "string"],
-          "format": "date-time"
+        "last_set_to_arrears_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
         },
-        "encoded_key": {
-          "type": ["null", "string"]
-        }
-      }
-    },
-    "days_in_arrears": {
-      "type": ["null", "integer"]
-    },
-    "account_sub_state": {
-      "type": ["null", "string"]
-    },
-    "loan_name": {
-      "type": ["null", "string"]
-    },
-    "interest_settings": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "interest_rate_review_unit": {
-          "type": ["null", "string"]
+        "notes": {
+            "type": ["null", "string"]
         },
-        "interest_spread": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20
-        },
-        "interest_rate": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20,
-          "minimum": -1000000000000000,
-          "maximum": 1000000000000000
-        },
-        "interest_calculation_method": {
-          "type": ["null", "string"]
-        },
-        "interest_rate_source": {
-          "type": ["null", "string"]
-        },
-        "interest_rate_review_count": {
-          "type": ["null", "integer"]
-        },
-        "interest_application_method": {
-          "type": ["null", "string"]
-        },
-        "interest_charge_frequency": {
-          "type": ["null", "string"]
-        },
-        "interest_type": {
-          "type": ["null", "string"]
-        },
-        "accrue_interest_after_maturity": {
-          "type": ["null", "boolean"]
-        },
-        "interest_balance_calculation_method": {
-          "type": ["null", "string"]
-        }
-      }
-    },
-    "assets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
+        "disbursement_details": {
+            "type": ["null", "object"],
             "additionalProperties": false,
             "properties": {
-              "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "deposit_account_key": {
-                "type": ["null", "string"]
-              },
-              "asset_name": {
-                "type": ["null", "string"]
-              },
-              "encoded_key": {
-                "type": ["null", "string"]
-              },
-              "guarantor_key": {
-                "type": ["null", "string"]
-              },
-              "guarantor_type": {
-                "type": ["null", "string"]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "last_interest_review_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "id": {
-      "type": ["null", "string"]
-    },
-    "assigned_user_key": {
-      "type": ["null", "string"]
-    },
-    "future_payments_acceptance": {
-      "type": ["null", "string"]
-    },
-    "locked_operations": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "accrued_interest": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
-    },
-    "accrued_penalty": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
-    },
-    "creation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "assigned_centre_key": {
-      "type": ["null", "string"]
-    },
-    "tranches": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "encoded_key": {
-                "type": ["null", "string"]
-              },
-              "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "disbursement_details": {
-                "type": ["null", "object"],
-                "additionalProperties": false,
-                "properties": {
-                  "expected_disbursement_date": {
+                "transaction_details": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "encoded_key": {
+                            "type": ["null", "string"]
+                        },
+                        "internal_transfer": {
+                            "type": ["null", "boolean"]
+                        },
+                        "transaction_channel_key": {
+                            "type": ["null", "string"]
+                        },
+                        "transaction_channel_id": {
+                            "type": ["null", "string"]
+                        },
+                        "target_deposit_account_key": {
+                            "type": ["null", "string"]
+                        }
+                    }
+                },
+                "expected_disbursement_date": {
                     "type": ["null", "string"],
                     "format": "date-time"
-                  },
-                  "disbursement_transaction_key": {
+                },
+                "fees": {
+                    "anyOf": [{
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "predefined_fee_encoded_key": {
+                                        "type": ["null", "string"]
+                                    },
+                                    "encoded_key": {
+                                        "type": ["null", "string"]
+                                    },
+                                    "amount": {
+                                        "type": ["null", "number"],
+                                        "multipleOf": 1e-10
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "first_repayment_date": {
+                    "type": ["null", "string"],
+                    "format": "date-time"
+                },
+                "disbursement_date": {
+                    "type": ["null", "string"],
+                    "format": "date-time"
+                },
+                "encoded_key": {
                     "type": ["null", "string"]
-                  }
                 }
-              },
-              "tranch_number": {
-                "type": ["null", "string"]
-              }
             }
-          }
         },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "approved_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "tax_rate": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-20,
-      "minimum": -1000000000000000,
-      "maximum": 1000000000000000
-    },
-    "last_tax_rate_review_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "interest_from_arrears_accrued": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
-    },
-    "schedule_settings": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "grace_period": {
-          "type": ["null", "integer"]
+        "days_in_arrears": {
+            "type": ["null", "integer"]
         },
-        "periodic_payment": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+        "account_sub_state": {
+            "type": ["null", "string"]
         },
-        "repayment_schedule_method": {
-          "type": ["null", "string"]
+        "loan_name": {
+            "type": ["null", "string"]
         },
-        "payment_plan": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "to_installment": {
-                    "type": ["null", "integer"]
-                  },
-                  "encoded_key": {
+        "interest_settings": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "interest_rate_review_unit": {
                     "type": ["null", "string"]
-                  },
-                  "amount": {
+                },
+                "interest_spread": {
                     "type": ["null", "number"],
-                    "multipleOf": 1e-10
-                  }
+                    "multipleOf": 1e-20
+                },
+                "interest_rate": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-20,
+                    "minimum": -1000000000000000,
+                    "maximum": 1000000000000000
+                },
+                "interest_calculation_method": {
+                    "type": ["null", "string"]
+                },
+                "interest_rate_source": {
+                    "type": ["null", "string"]
+                },
+                "interest_rate_review_count": {
+                    "type": ["null", "integer"]
+                },
+                "interest_application_method": {
+                    "type": ["null", "string"]
+                },
+                "interest_charge_frequency": {
+                    "type": ["null", "string"]
+                },
+                "interest_type": {
+                    "type": ["null", "string"]
+                },
+                "accrue_interest_after_maturity": {
+                    "type": ["null", "boolean"]
+                },
+                "interest_balance_calculation_method": {
+                    "type": ["null", "string"]
                 }
-              }
-            },
-            {
-              "type": "null"
             }
-          ]
         },
-        "short_month_handling_method": {
-          "type": ["null", "string"]
-        },
-        "repayment_installments": {
-          "type": ["null", "integer"]
-        },
-        "grace_period_type": {
-          "type": ["null", "string"]
-        },
-        "principal_repayment_interval": {
-          "type": ["null", "integer"]
-        },
-        "has_custom_schedule": {
-          "type": ["null", "boolean"]
-        },
-        "repayment_period_unit": {
-          "type": ["null", "string"]
-        },
-        "fixed_days_of_month": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              }
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "schedule_due_dates_method": {
-          "type": ["null", "string"]
-        },
-        "repayment_period_count": {
-          "type": ["null", "integer"]
-        },
-        "default_first_repayment_due_date_offset": {
-          "type": ["null", "integer"]
-        }
-      }
-    },
-    "days_late": {
-      "type": ["null", "integer"]
-    },
-    "payment_method": {
-      "type": ["null", "string"]
-    },
-    "account_holder_key": {
-      "type": ["null", "string"]
-    },
-    "late_payments_recalculation_method": {
-      "type": ["null", "string"]
-    },
-    "funding_sources": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "interest_commission": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "deposit_account_key": {
-                "type": ["null", "string"]
-              },
-              "asset_name": {
-                "type": ["null", "string"]
-              },
-              "encoded_key": {
-                "type": ["null", "string"]
-              },
-              "id": {
-                "type": ["null", "string"]
-              },
-              "guarantor_key": {
-                "type": ["null", "string"]
-              },
-              "guarantor_type": {
-                "type": ["null", "string"]
-              },
-              "share_percentage": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "account_holder_type": {
-      "type": ["null", "string"]
-    },
-    "arrears_tolerance_period": {
-      "type": ["null", "integer"]
-    },
-    "last_interest_applied_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "rescheduled_account_key": {
-      "type": ["null", "string"]
-    },
-    "activation_transaction_key": {
-      "type": ["null", "string"]
-    },
-    "assigned_branch_key": {
-      "type": ["null", "string"]
-    },
-    "balances": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "interest_from_arrears_paid": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "principal_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "interest_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "principal_paid": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "penalty_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "fees_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "penalty_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "redraw_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "interest_from_arrears_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "principal_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "interest_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "penalty_paid": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "fees_paid": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "interest_from_arrears_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "fees_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "interest_paid": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        }
-      }
-    },
-    "credit_arrangement_key": {
-      "type": ["null", "string"]
-    },
-    "interest_commission": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
-    },
-    "encoded_key": {
-      "type": ["null", "string"]
-    },
-    "last_appraisal_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "penalty_settings": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "loan_penalty_calculation_method": {
-          "type": ["null", "string"]
-        },
-        "penalty_rate": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20,
-          "minimum": -1000000000000000,
-          "maximum": 1000000000000000
-        }
-      }
-    },
-    "settlement_account_key": {
-      "type": ["null", "string"]
-    },
-    "last_modified_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "principal_payment_settings": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "include_interest_in_floor_amount": {
-          "type": ["null", "boolean"]
-        },
-        "total_due_payment": {
-          "type": ["null", "string"]
-        },
-        "amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "principal_floor_value": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "principal_payment_method": {
-          "type": ["null", "string"]
-        },
-        "percentage": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20,
-          "minimum": -1000000000000000,
-          "maximum": 1000000000000000
-        },
-        "include_fees_in_floor_amount": {
-          "type": ["null", "boolean"]
-        },
-        "encoded_key": {
-          "type": ["null", "string"]
-        },
-        "total_due_amount_floor": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "principal_ceiling_value": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        }
-      }
-    },
-    "last_locked_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "loan_amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
-    },
-    "closed_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "product_type_key": {
-      "type": ["null", "string"]
-    },
-    "allow_offset": {
-      "type": ["null", "boolean"]
-    },
-    "guarantors": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "deposit_account_key": {
-                "type": ["null", "string"]
-              },
-              "asset_name": {
-                "type": ["null", "string"]
-              },
-              "encoded_key": {
-                "type": ["null", "string"]
-              },
-              "guarantor_key": {
-                "type": ["null", "string"]
-              },
-              "guarantor_type": {
-                "type": ["null", "string"]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "account_arrears_settings": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "monthly_tolerance_day": {
-          "type": ["null", "integer"]
-        },
-        "non_working_days_method": {
-          "type": ["null", "string"]
-        },
-        "tolerance_period": {
-          "type": ["null", "integer"]
-        },
-        "encoded_key": {
-          "type": ["null", "string"]
-        },
-        "tolerance_calculation_method": {
-          "type": ["null", "string"]
-        },
-        "date_calculation_method": {
-          "type": ["null", "string"]
-        }
-      }
-    },
-    "custom_field_sets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_field_set_id": {
-                "type": ["null", "string"]
-              },
-              "custom_field_values": {
-                "anyOf": [
-                  {
+        "assets": {
+            "anyOf": [{
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "custom_field_id": {
-                          "type": ["null", "string"]
-                        },
-                        "custom_field_value": {
-                          "type": ["null", "string"]
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "amount": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "deposit_account_key": {
+                                "type": ["null", "string"]
+                            },
+                            "asset_name": {
+                                "type": ["null", "string"]
+                            },
+                            "encoded_key": {
+                                "type": ["null", "string"]
+                            },
+                            "guarantor_key": {
+                                "type": ["null", "string"]
+                            },
+                            "guarantor_type": {
+                                "type": ["null", "string"]
+                            }
                         }
-                      }
                     }
-                  },
-                  {
+                },
+                {
                     "type": "null"
-                  }
-                ]
-              }
-            }
-          }
+                }
+            ]
         },
-        {
-          "type": "null"
+        "last_interest_review_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "id": {
+            "type": ["null", "string"]
+        },
+        "assigned_user_key": {
+            "type": ["null", "string"]
+        },
+        "future_payments_acceptance": {
+            "type": ["null", "string"]
+        },
+        "locked_operations": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "accrued_interest": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-10
+        },
+        "accrued_penalty": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-10
+        },
+        "creation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "assigned_centre_key": {
+            "type": ["null", "string"]
+        },
+        "tranches": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "encoded_key": {
+                                "type": ["null", "string"]
+                            },
+                            "amount": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "disbursement_details": {
+                                "type": ["null", "object"],
+                                "additionalProperties": false,
+                                "properties": {
+                                    "expected_disbursement_date": {
+                                        "type": ["null", "string"],
+                                        "format": "date-time"
+                                    },
+                                    "disbursement_transaction_key": {
+                                        "type": ["null", "string"]
+                                    }
+                                }
+                            },
+                            "tranch_number": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "approved_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "tax_rate": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-20,
+            "minimum": -1000000000000000,
+            "maximum": 1000000000000000
+        },
+        "last_tax_rate_review_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "interest_from_arrears_accrued": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-10
+        },
+        "schedule_settings": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "grace_period": {
+                    "type": ["null", "integer"]
+                },
+                "periodic_payment": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "repayment_schedule_method": {
+                    "type": ["null", "string"]
+                },
+                "payment_plan": {
+                    "anyOf": [{
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "to_installment": {
+                                        "type": ["null", "integer"]
+                                    },
+                                    "encoded_key": {
+                                        "type": ["null", "string"]
+                                    },
+                                    "amount": {
+                                        "type": ["null", "number"],
+                                        "multipleOf": 1e-10
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "short_month_handling_method": {
+                    "type": ["null", "string"]
+                },
+                "repayment_installments": {
+                    "type": ["null", "integer"]
+                },
+                "grace_period_type": {
+                    "type": ["null", "string"]
+                },
+                "principal_repayment_interval": {
+                    "type": ["null", "integer"]
+                },
+                "has_custom_schedule": {
+                    "type": ["null", "boolean"]
+                },
+                "repayment_period_unit": {
+                    "type": ["null", "string"]
+                },
+                "fixed_days_of_month": {
+                    "anyOf": [{
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "schedule_due_dates_method": {
+                    "type": ["null", "string"]
+                },
+                "repayment_period_count": {
+                    "type": ["null", "integer"]
+                },
+                "default_first_repayment_due_date_offset": {
+                    "type": ["null", "integer"]
+                }
+            }
+        },
+        "days_late": {
+            "type": ["null", "integer"]
+        },
+        "payment_method": {
+            "type": ["null", "string"]
+        },
+        "account_holder_key": {
+            "type": ["null", "string"]
+        },
+        "late_payments_recalculation_method": {
+            "type": ["null", "string"]
+        },
+        "funding_sources": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "amount": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "interest_commission": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "deposit_account_key": {
+                                "type": ["null", "string"]
+                            },
+                            "asset_name": {
+                                "type": ["null", "string"]
+                            },
+                            "encoded_key": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "string"]
+                            },
+                            "guarantor_key": {
+                                "type": ["null", "string"]
+                            },
+                            "guarantor_type": {
+                                "type": ["null", "string"]
+                            },
+                            "share_percentage": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "account_holder_type": {
+            "type": ["null", "string"]
+        },
+        "arrears_tolerance_period": {
+            "type": ["null", "integer"]
+        },
+        "last_interest_applied_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "rescheduled_account_key": {
+            "type": ["null", "string"]
+        },
+        "activation_transaction_key": {
+            "type": ["null", "string"]
+        },
+        "assigned_branch_key": {
+            "type": ["null", "string"]
+        },
+        "balances": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "interest_from_arrears_paid": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "principal_due": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "interest_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "principal_paid": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "penalty_due": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "fees_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "penalty_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "redraw_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "interest_from_arrears_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "principal_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "interest_due": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "penalty_paid": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "fees_paid": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "interest_from_arrears_due": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "fees_due": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "interest_paid": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                }
+            }
+        },
+        "credit_arrangement_key": {
+            "type": ["null", "string"]
+        },
+        "interest_commission": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-10
+        },
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "last_appraisal_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "penalty_settings": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "loan_penalty_calculation_method": {
+                    "type": ["null", "string"]
+                },
+                "penalty_rate": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-20,
+                    "minimum": -1000000000000000,
+                    "maximum": 1000000000000000
+                }
+            }
+        },
+        "settlement_account_key": {
+            "type": ["null", "string"]
+        },
+        "last_modified_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "principal_payment_settings": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "include_interest_in_floor_amount": {
+                    "type": ["null", "boolean"]
+                },
+                "total_due_payment": {
+                    "type": ["null", "string"]
+                },
+                "amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "principal_floor_value": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "principal_payment_method": {
+                    "type": ["null", "string"]
+                },
+                "percentage": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-20,
+                    "minimum": -1000000000000000,
+                    "maximum": 1000000000000000
+                },
+                "include_fees_in_floor_amount": {
+                    "type": ["null", "boolean"]
+                },
+                "encoded_key": {
+                    "type": ["null", "string"]
+                },
+                "total_due_amount_floor": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "principal_ceiling_value": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                }
+            }
+        },
+        "last_locked_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "loan_amount": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-10
+        },
+        "closed_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "product_type_key": {
+            "type": ["null", "string"]
+        },
+        "allow_offset": {
+            "type": ["null", "boolean"]
+        },
+        "guarantors": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "amount": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "deposit_account_key": {
+                                "type": ["null", "string"]
+                            },
+                            "asset_name": {
+                                "type": ["null", "string"]
+                            },
+                            "encoded_key": {
+                                "type": ["null", "string"]
+                            },
+                            "guarantor_key": {
+                                "type": ["null", "string"]
+                            },
+                            "guarantor_type": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "account_arrears_settings": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "monthly_tolerance_day": {
+                    "type": ["null", "integer"]
+                },
+                "non_working_days_method": {
+                    "type": ["null", "string"]
+                },
+                "tolerance_period": {
+                    "type": ["null", "integer"]
+                },
+                "encoded_key": {
+                    "type": ["null", "string"]
+                },
+                "tolerance_calculation_method": {
+                    "type": ["null", "string"]
+                },
+                "date_calculation_method": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "custom_fields": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "field_set_id": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "string"]
+                            },
+                            "value": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/tap_mambu/schemas/loan_transactions.json
+++ b/tap_mambu/schemas/loan_transactions.json
@@ -1,338 +1,319 @@
 {
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "migration_event_key": {
-      "type": ["null", "string"]
-    },
-    "transaction_details": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "transaction_channel_id": {
-          "type": ["null", "string"]
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "migration_event_key": {
+            "type": ["null", "string"]
         },
-        "transaction_channel_key": {
-          "type": ["null", "string"]
-        }
-      }
-    },
-    "fees": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
+        "transaction_details": {
+            "type": ["null", "object"],
             "additionalProperties": false,
             "properties": {
-              "name": {
-                "type": ["null", "string"]
-              },
-              "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "trigger": {
-                "type": ["null", "string"]
-              },
-              "tax_amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "predefined_fee_key": {
-                "type": ["null", "string"]
-              }
+                "transaction_channel_id": {
+                    "type": ["null", "string"]
+                },
+                "transaction_channel_key": {
+                    "type": ["null", "string"]
+                }
             }
-          }
         },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "notes": {
-      "type": ["null", "string"]
-    },
-    "affected_amounts": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "fees_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "overdraft_interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "overdraft_fees_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "fraction_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "technical_overdraft_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "overdraft_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "technical_overdraft_interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "funds_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        }
-      }
-    },
-    "taxes": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "tax_interest_from_arrears_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "tax_on_fees_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "tax_rate": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20,
-          "minimum": -1000000000000000,
-          "maximum": 1000000000000000
-        },
-        "tax_on_interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "tax_on_penalty_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "deferred_tax_on_interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        }
-      }
-    },
-    "till_key": {
-      "type": ["null", "string"]
-    },
-    "adjustment_transaction_key": {
-      "type": ["null", "string"]
-    },
-    "type": {
-      "type": ["null", "string"]
-    },
-    "branch_key": {
-      "type": ["null", "string"]
-    },
-    "terms": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "interest_settings": {
-          "type": ["null", "object"],
-          "additionalProperties": false,
-          "properties": {
-            "interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
-              "minimum": -1000000000000000,
-              "maximum": 1000000000000000
-            },
-            "index_interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
-              "minimum": -1000000000000000,
-              "maximum": 1000000000000000
-            }
-          }
-        },
-        "principal_payment_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "principal_payment_percentage": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20,
-          "minimum": -1000000000000000,
-          "maximum": 1000000000000000
-        }
-      }
-    },
-    "transfer_details": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "linked_loan_transaction_key": {
-          "type": ["null", "string"]
-        },
-        "linked_deposit_transaction_key": {
-          "type": ["null", "string"]
-        }
-      }
-    },
-    "parent_loan_transaction_key": {
-      "type": ["null", "string"]
-    },
-    "custom_payment_amounts": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "tax_on_amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
-              },
-              "custom_payment_amount_type": {
-                "type": ["null", "string"]
-              }                    
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "encoded_key": {
-      "type": ["null", "string"]
-    },
-    "id": {
-      "type": ["null", "string"]
-    },
-    "original_currency_code": {
-      "type": ["null", "string"]
-    },
-    "original_transaction_key": {
-      "type": ["null", "string"]
-    },
-    "amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
-    },
-    "centre_key": {
-      "type": ["null", "string"]
-    },
-    "external_id": {
-      "type": ["null", "string"]
-    },
-    "value_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "creation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "user_key": {
-      "type": ["null", "string"]
-    },
-    "parent_account_key": {
-      "type": ["null", "string"]
-    },
-    "original_amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
-    },
-
-    "linked_loan_transaction_key": {
-      "type": ["null", "string"]
-    },
-    "account_balances": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "redraw_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "principal_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "total_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "expected_principal_redraw": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "advance_position": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        },
-        "arrears_position": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
-        }
-      }
-    },
-    "booking_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "custom_field_sets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_field_set_id": {
-                "type": ["null", "string"]
-              },
-              "custom_field_values": {
-                "anyOf": [
-                  {
+        "fees": {
+            "anyOf": [{
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "custom_field_id": {
-                          "type": ["null", "string"]
-                        },
-                        "custom_field_value": {
-                          "type": ["null", "string"]
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": {
+                                "type": ["null", "string"]
+                            },
+                            "amount": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "trigger": {
+                                "type": ["null", "string"]
+                            },
+                            "tax_amount": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "predefined_fee_key": {
+                                "type": ["null", "string"]
+                            }
                         }
-                      }
                     }
-                  },
-                  {
+                },
+                {
                     "type": "null"
-                  }
-                ]
-              }
-            }
-          }
+                }
+            ]
         },
-        {
-          "type": "null"
+        "notes": {
+            "type": ["null", "string"]
+        },
+        "affected_amounts": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "fees_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "overdraft_interest_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "overdraft_fees_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "fraction_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "technical_overdraft_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "overdraft_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "interest_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "technical_overdraft_interest_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "funds_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                }
+            }
+        },
+        "taxes": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "tax_interest_from_arrears_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "tax_on_fees_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "tax_rate": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-20,
+                    "minimum": -1000000000000000,
+                    "maximum": 1000000000000000
+                },
+                "tax_on_interest_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "tax_on_penalty_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "deferred_tax_on_interest_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                }
+            }
+        },
+        "till_key": {
+            "type": ["null", "string"]
+        },
+        "adjustment_transaction_key": {
+            "type": ["null", "string"]
+        },
+        "type": {
+            "type": ["null", "string"]
+        },
+        "branch_key": {
+            "type": ["null", "string"]
+        },
+        "terms": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "interest_settings": {
+                    "type": ["null", "object"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "interest_rate": {
+                            "type": ["null", "number"],
+                            "multipleOf": 1e-20,
+                            "minimum": -1000000000000000,
+                            "maximum": 1000000000000000
+                        },
+                        "index_interest_rate": {
+                            "type": ["null", "number"],
+                            "multipleOf": 1e-20,
+                            "minimum": -1000000000000000,
+                            "maximum": 1000000000000000
+                        }
+                    }
+                },
+                "principal_payment_amount": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "principal_payment_percentage": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-20,
+                    "minimum": -1000000000000000,
+                    "maximum": 1000000000000000
+                }
+            }
+        },
+        "transfer_details": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "linked_loan_transaction_key": {
+                    "type": ["null", "string"]
+                },
+                "linked_deposit_transaction_key": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "parent_loan_transaction_key": {
+            "type": ["null", "string"]
+        },
+        "custom_payment_amounts": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "tax_on_amount": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "amount": {
+                                "type": ["null", "number"],
+                                "multipleOf": 1e-10
+                            },
+                            "custom_payment_amount_type": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "id": {
+            "type": ["null", "string"]
+        },
+        "original_currency_code": {
+            "type": ["null", "string"]
+        },
+        "original_transaction_key": {
+            "type": ["null", "string"]
+        },
+        "amount": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-10
+        },
+        "centre_key": {
+            "type": ["null", "string"]
+        },
+        "external_id": {
+            "type": ["null", "string"]
+        },
+        "value_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "creation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "user_key": {
+            "type": ["null", "string"]
+        },
+        "parent_account_key": {
+            "type": ["null", "string"]
+        },
+        "original_amount": {
+            "type": ["null", "number"],
+            "multipleOf": 1e-10
+        },
+
+        "linked_loan_transaction_key": {
+            "type": ["null", "string"]
+        },
+        "account_balances": {
+            "type": ["null", "object"],
+            "additionalProperties": false,
+            "properties": {
+                "redraw_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "principal_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "total_balance": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "expected_principal_redraw": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "advance_position": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                },
+                "arrears_position": {
+                    "type": ["null", "number"],
+                    "multipleOf": 1e-10
+                }
+            }
+        },
+        "booking_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "custom_fields": {
+            "anyOf": [{
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "field_set_id": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "string"]
+                            },
+                            "value": {
+                                "type": ["null", "string"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/tap_mambu/schemas/tasks.json
+++ b/tap_mambu/schemas/tasks.json
@@ -44,45 +44,28 @@
     "state": {
       "type": ["null", "string"]
     },
-    "custom_field_sets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "custom_field_set_id": {
-                "type": ["null", "string"]
-              },
-              "custom_field_values": {
-                "anyOf": [
-                  {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "custom_field_id": {
+    "custom_fields": {
+      "anyOf": [{
+              "type": "array",
+              "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                      "field_set_id": {
                           "type": ["null", "string"]
-                        },
-                        "custom_field_value": {
+                      },
+                      "id": {
                           "type": ["null", "string"]
-                        }
+                      },
+                      "value": {
+                          "type": ["null", "string"]
                       }
-                    }
-                  },
-                  {
-                    "type": "null"
                   }
-                ]
               }
-            }
+          },
+          {
+              "type": "null"
           }
-        },
-        {
-          "type": "null"
-        }
       ]
     }
   }

--- a/tap_mambu/schemas/users.json
+++ b/tap_mambu/schemas/users.json
@@ -1,163 +1,144 @@
 {
-  "type": "object",
-  "additionalProperties": false,
-  "properties": {
-    "last_name": {
-      "type": ["null", "string"]
-    },
-    "access": {
-      "type": ["null", "object"],
-      "additionalProperties": false,
-      "properties": {
-        "can_manage_entities_assigned_to_other_officers": {
-          "type": ["null", "string"]
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "last_name": {
+            "type": ["null", "string"]
         },
-        "mambu_access": {
-          "type": ["null", "boolean"]
-        },
-        "administrator_access": {
-          "type": ["null", "boolean"]
-        },
-        "api_access": {
-          "type": ["null", "boolean"]
-        },
-        "permissions": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": ["null", "boolean"]
-              }
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "credit_officer_access": {
-          "type": ["null", "boolean"]
-        },
-        "can_manage_all_branches": {
-          "type": ["null", "boolean"]
-        },
-        "support_access": {
-          "type": ["null", "boolean"]
-        },
-        "managed_branches": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "branch_key": {
-                    "type": ["null", "string"]
-                  }
-                }
-              }
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "teller_access": {
-          "type": ["null", "boolean"]
-        }
-      }
-    },
-    "notes": {
-      "type": ["null", "string"]
-    },
-    "last_logged_in_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "last_modified_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "home_phone": {
-      "type": ["null", "string"]
-    },
-    "language": {
-      "type": ["null", "string"]
-    },
-    "creation_date": {
-      "type": ["null", "string"],
-      "format": "date-time"
-    },
-    "title": {
-      "type": ["null", "string"]
-    },
-    "assigned_branch_key": {
-      "type": ["null", "string"]
-    },
-    "first_name": {
-      "type": ["null", "string"]
-    },
-    "mobile_phone": {
-      "type": ["null", "string"]
-    },
-    "user_state": {
-      "type": ["null", "string"]
-    },
-    "two_factor_authentication": {
-      "type": ["null", "boolean"]
-    },
-    "encoded_key": {
-      "type": ["null", "string"]
-    },
-    "id": {
-      "type": ["null", "string"]
-    },
-    "email": {
-      "type": ["null", "string"]
-    },
-    "username": {
-      "type": ["null", "string"]
-    },
-    "custom_field_sets": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
+        "access": {
+            "type": ["null", "object"],
             "additionalProperties": false,
             "properties": {
-              "custom_field_set_id": {
-                "type": ["null", "string"]
-              },
-              "custom_field_values": {
-                "anyOf": [
-                  {
+                "can_manage_entities_assigned_to_other_officers": {
+                    "type": ["null", "string"]
+                },
+                "mambu_access": {
+                    "type": ["null", "boolean"]
+                },
+                "administrator_access": {
+                    "type": ["null", "boolean"]
+                },
+                "api_access": {
+                    "type": ["null", "boolean"]
+                },
+                "permissions": {
+                    "anyOf": [{
+                            "type": "array",
+                            "items": {
+                                "type": ["null", "boolean"]
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "credit_officer_access": {
+                    "type": ["null", "boolean"]
+                },
+                "can_manage_all_branches": {
+                    "type": ["null", "boolean"]
+                },
+                "support_access": {
+                    "type": ["null", "boolean"]
+                },
+                "managed_branches": {
+                    "anyOf": [{
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "branch_key": {
+                                        "type": ["null", "string"]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "teller_access": {
+                    "type": ["null", "boolean"]
+                }
+            }
+        },
+        "notes": {
+            "type": ["null", "string"]
+        },
+        "last_logged_in_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "last_modified_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "home_phone": {
+            "type": ["null", "string"]
+        },
+        "language": {
+            "type": ["null", "string"]
+        },
+        "creation_date": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "title": {
+            "type": ["null", "string"]
+        },
+        "assigned_branch_key": {
+            "type": ["null", "string"]
+        },
+        "first_name": {
+            "type": ["null", "string"]
+        },
+        "mobile_phone": {
+            "type": ["null", "string"]
+        },
+        "user_state": {
+            "type": ["null", "string"]
+        },
+        "two_factor_authentication": {
+            "type": ["null", "boolean"]
+        },
+        "encoded_key": {
+            "type": ["null", "string"]
+        },
+        "id": {
+            "type": ["null", "string"]
+        },
+        "email": {
+            "type": ["null", "string"]
+        },
+        "username": {
+            "type": ["null", "string"]
+        },
+        "custom_fields": {
+            "anyOf": [{
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "custom_field_id": {
-                          "type": ["null", "string"]
-                        },
-                        "custom_field_value": {
-                          "type": ["null", "string"]
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "field_set_id": {
+                                "type": ["null", "string"]
+                            },
+                            "id": {
+                                "type": ["null", "string"]
+                            },
+                            "value": {
+                                "type": ["null", "string"]
+                            }
                         }
-                      }
                     }
-                  },
-                  {
+                },
+                {
                     "type": "null"
-                  }
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
+                }
+            ]
         }
-      ]
-    }  
-  }
+    }
 }

--- a/tap_mambu/transform.py
+++ b/tap_mambu/transform.py
@@ -52,12 +52,12 @@ def convert_custom_fields(this_json):
         for key in record:
             if isinstance(record[key], dict):
                 if key[:1] == '_':
-                    field = {}
                     for cf_key, cf_value in record[key].items():
+                        field = {}
                         field['field_set_id'] = key
                         field['id'] = cf_key
                         field['value'] = cf_value
-                    cust_field_sets.append(field)
+                        cust_field_sets.append(field)
         new_json[i]['custom_fields'] = cust_field_sets
         i = i + 1
     return new_json

--- a/tap_mambu/transform.py
+++ b/tap_mambu/transform.py
@@ -52,17 +52,13 @@ def convert_custom_fields(this_json):
         for key in record:
             if isinstance(record[key], dict):
                 if key[:1] == '_':
-                    cust_field_set = {}
-                    cust_field_set['customFieldSetId'] = key
-                    cust_field_set_fields = []
+                    field = {}
                     for cf_key, cf_value in record[key].items():
-                        field = {}
-                        field['customFieldId'] = cf_key
-                        field['customFieldValue'] = cf_value
-                        cust_field_set_fields.append(field)
-                    cust_field_set['customFieldValues'] = cust_field_set_fields
-                    cust_field_sets.append(cust_field_set)
-        new_json[i]['customFieldSets'] = cust_field_sets
+                        field['field_set_id'] = key
+                        field['id'] = cf_key
+                        field['value'] = cf_value
+                    cust_field_sets.append(field)
+        new_json[i]['custom_fields'] = cust_field_sets
         i = i + 1
     return new_json
 


### PR DESCRIPTION
# Description of change
Update transform and schema for custom fields to improve flattening that happens in some destinations(Postgres in particular). 

New schema for custom fields:

```json
"custom_fields": {
            "anyOf": [{
                    "type": "array",
                    "items": {
                        "type": "object",
                        "additionalProperties": false,
                        "properties": {
                            "field_set_id": {
                                "type": ["null", "string"]
                            },
                            "id": {
                                "type": ["null", "string"]
                            },
                            "value": {
                                "type": ["null", "string"]
                            }
                        }
                    }
                },
                {
                    "type": "null"
                }
            ]
        }
```

# Manual QA steps
Ran 

* discover
* check-tap
```
Checking stdin for valid Singer-formatted data
The output is valid.
It contained 458 messages for 19 streams.

     31 schema messages
    366 record messages
     61 state messages

Details by stream:
+----------------------+---------+---------+
| stream               | records | schemas |
+----------------------+---------+---------+
| communications       | 0       | 1       |
| clients              | 2       | 1       |
| deposit_products     | 1       | 1       |
| loan_products        | 1       | 1       |
| gl_accounts          | 1       | 5       |
| deposit_transactions | 29      | 1       |
| gl_journal_entries   | 263     | 1       |
| branches             | 1       | 1       |
| deposit_accounts     | 3       | 1       |
| cards                | 1       | 3       |
| credit_arrangements  | 0       | 1       |
| tasks                | 1       | 1       |
| custom_field_sets    | 21      | 1       |
| loan_accounts        | 1       | 1       |
| loan_repayments      | 35      | 7       |
| users                | 1       | 1       |
| centres              | 2       | 1       |
| loan_transactions    | 3       | 1       |
| groups               | 0       | 1       |
+----------------------+---------+---------+
```
* target-stitch

 
# Risks
 - 
 
# Rollback steps
 - revert this branch
