### PR TITLE
Add apikey authentication 

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ This tap:
     {
         "username": "YOUR_USERNAME",
         "password": "YOUR_PASSWORD",
+        "apikey": "YOUR_APIKEY",
         "subdomain": "YOUR_SUBDOMAIN",
         "start_date": "2019-01-01T00:00:00Z",
         "lookback_window: 30,

--- a/config.json.example
+++ b/config.json.example
@@ -1,6 +1,7 @@
 {
     "username": "YOUR_USERNAME",
     "password": "YOUR_PASSWORD",
+    "apikey": "YOUR_APIKEY",
     "subdomain": "YOUR_SUBDOMAIN",
     "start_date": "2019-01-01T00:00:00Z",
     "user_agent": "tap-mambu <api_user_email@your_company.com>"

--- a/tap_mambu/__init__.py
+++ b/tap_mambu/__init__.py
@@ -12,8 +12,6 @@ from tap_mambu.sync import sync
 LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = [
-    'username',
-    'password',
     'subdomain',
     'start_date',
     'user_agent'
@@ -34,8 +32,9 @@ def main():
 
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
-    with MambuClient(parsed_args.config['username'],
-                     parsed_args.config['password'],
+    with MambuClient(parsed_args.config.get('username'),
+                     parsed_args.config.get('password'),
+                     parsed_args.config.get('apikey'),
                      parsed_args.config['subdomain'],
                      int(parsed_args.config.get('page_size', DEFAULT_PAGE_SIZE)),
                      user_agent=parsed_args.config['user_agent']) as client:


### PR DESCRIPTION
# Description of change
Add `apikey` [authentication](https://support.mambu.com/docs/api-consumers).
This enables the use of `username`/`password` or the API Consumer `apikey`.
If both `username`/`password` and `apikey` are provided, the former takes precedence.

# Manual QA steps
 - pylint
```
pylint tap_mambu -d missing-docstring -d logging-format-interpolation -d too-many-locals -d too-many-arguments
Your code has been rated at 9.84/10 (previous run: 9.84/10, -0.00)
 ```

# Risks
 - 
 
# Rollback steps
 - revert this branch
