### PR TITLE
Add tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build
+      - build:
+          context: circleci-user
   build_daily:
     triggers:
       - schedule:
@@ -45,4 +46,5 @@ workflows:
               only:
                 - master
     jobs:
-      - build
+      - build:
+          context: circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,19 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json /usr/local/share/virtualenvs/tap-mambu/lib/python3.5/site-packages/tap_mambu/schemas/*.json
+      - run:
+          name: 'Integration Tests'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            run-test --tap=tap-mambu \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$SANDBOX_PASSWORD \
+                     --client-id=50 \
+                     tests
 workflows:
   version: 2
   commit:

--- a/tap_mambu/discover.py
+++ b/tap_mambu/discover.py
@@ -1,3 +1,4 @@
+from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_mambu.schema import get_schemas, STREAMS
 
@@ -7,14 +8,19 @@ def discover():
 
     for stream_name, schema_dict in schemas.items():
         schema = Schema.from_dict(schema_dict)
-        mdata = field_metadata[stream_name]
+        mdata = metadata.to_map(field_metadata[stream_name])
+
+        stream = STREAMS[stream_name]
+        if stream.get('replication_method') == 'INCREMENTAL':
+            for field_name in stream.get('replication_keys'):
+                metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
 
         catalog.streams.append(CatalogEntry(
             stream=stream_name,
             tap_stream_id=stream_name,
-            key_properties=STREAMS[stream_name]['key_properties'],
+            key_properties=stream['key_properties'],
             schema=schema,
-            metadata=mdata
+            metadata=metadata.to_list(mdata)
         ))
 
     return catalog

--- a/tests/base.py
+++ b/tests/base.py
@@ -247,7 +247,7 @@ class MambuBaseTest(unittest.TestCase):
             'start_date': '2019-01-01T00:00:00Z',
             'username': os.environ['TAP_MAMBU_USERNAME'],
             'subdomain': os.environ['TAP_MAMBU_SUBDOMAIN'],
-            'page_size': '100'
+            'page_size': 100
             }
 
     def get_credentials(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -393,3 +393,28 @@ class MambuBaseTest(unittest.TestCase):
                     for mdata in entry_metadata:
                         if mdata.get('breadcrumb') == []:
                             self.assertFalse(mdata.get('metadata').get('selected'))
+
+    def make_connection_and_run_sync(self, create_connection_kwargs=None, selection_kwargs=None):
+        """
+        These lines of code are at the start of every test, and some tests repeat this logic a 
+        second time
+        """
+        if create_connection_kwargs is None:
+            create_connection_kwargs = {}
+
+        if selection_kwargs is None:
+            selection_kwargs = {}
+
+        conn_id = self.create_connection(**create_connection_kwargs)
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        self.select_all_streams_and_fields(conn_id, catalogs, **selection_kwargs)
+        self.verify_stream_and_field_selection(conn_id)
+
+        # Run a sync job using orchestrator
+        record_count = self.run_and_verify_sync(conn_id)
+
+        bookmarks = menagerie.get_state(conn_id)
+        records = runner.get_records_from_target_output()
+
+        return conn_id, record_count, bookmarks, records

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,9 +2,8 @@
 Setup expectations for test sub classes
 Run discovery for as a prerequisite for most tests
 """
-import unittest
 import os
-
+import unittest
 from tap_tester import connections, menagerie, runner
 
 
@@ -234,7 +233,6 @@ class MambuBaseTest(unittest.TestCase):
             }
         }
 
-
     def create_connection(self, original_properties: bool = True):
         """Create a new connection with the test name"""
         # Create the connection
@@ -268,8 +266,7 @@ class MambuBaseTest(unittest.TestCase):
 
     def expected_primary_keys(self):
         """
-        return a dictionary with key of table name
-        and value as a set of primary key fields
+        return a dictionary with key of table name and value as a set of primary key fields
         """
         return {table: properties.get(self.PRIMARY_KEYS, set())
                 for table, properties
@@ -277,8 +274,7 @@ class MambuBaseTest(unittest.TestCase):
 
     def expected_replication_keys(self):
         """
-        return a dictionary with key of table name
-        and value as a set of replication key fields
+        return a dictionary with key of table name and value as a set of replication key fields
         """
         return {table: properties.get(self.REPLICATION_KEYS, set())
                 for table, properties
@@ -286,11 +282,13 @@ class MambuBaseTest(unittest.TestCase):
 
     def expected_automatic_fields(self):
         """
-        return a dictionary with key of table name and value as a set of
-        primary key and replication key fields
+        return a dictionary with key of table name and value as a set of primary key and replication
+        key fields
         """
-        return {table : self.expected_primary_keys()[table] | self.expected_replication_keys()[table]
-                for table in self.expected_metadata().keys()}
+        return {
+            table : self.expected_primary_keys()[table] | self.expected_replication_keys()[table]
+            for table in self.expected_metadata().keys()
+        }
 
     def expected_replication_method(self):
         """return a dictionary with key of table name nd value of replication method"""
@@ -316,8 +314,7 @@ class MambuBaseTest(unittest.TestCase):
     def run_and_verify_sync(self, conn_id):
         """
         Run a sync job and make sure it exited properly.
-        Return a dictionary with keys of streams synced
-        and values of records synced for each stream
+        Return a dictionary with keys of streams synced and values of records synced for each stream
         """
         # Run a sync job using orchestrator
         sync_job_name = runner.run_sync_mode(self, conn_id)
@@ -352,10 +349,15 @@ class MambuBaseTest(unittest.TestCase):
             unique_records.add(tuple(record_primary_key))
         return unique_records
 
+    def verify_is_selected(self, is_selected):
+        """This is the assertion for the metadata for each field for every stream"""
+        self.assertTrue(is_selected)
+
     def verify_stream_and_field_selection(self, conn_id):
         """
         For expected sync streams, verify that
-        - all fields are selected
+        - fields that should be selected are selected
+          - controlled by `self.verify_is_selected()`
         - automatic fields are automatic
         - non-automatic fields are "inclusion": "available"
 
@@ -387,7 +389,7 @@ class MambuBaseTest(unittest.TestCase):
                             if field_name in automatic_fields:
                                 self.assertTrue(inclusion == 'automatic')
                             else:
-                                self.assertTrue(is_selected)
+                                self.verify_is_selected(is_selected)
                                 self.assertTrue(inclusion == 'available')
                 else:
                     for mdata in entry_metadata:
@@ -396,7 +398,7 @@ class MambuBaseTest(unittest.TestCase):
 
     def make_connection_and_run_sync(self, create_connection_kwargs=None, selection_kwargs=None):
         """
-        These lines of code are at the start of every test, and some tests repeat this logic a 
+        These lines of code are at the start of every test, and some tests repeat this logic a
         second time
         """
         if create_connection_kwargs is None:

--- a/tests/base.py
+++ b/tests/base.py
@@ -335,11 +335,6 @@ class MambuBaseTest(unittest.TestCase):
 
         return sync_record_count
 
-    def filter_output_file_for_records(self, output_file, stream_name):
-        return [message['data']
-                for message in output_file[stream_name]['messages']
-                if message['action'] == 'upsert']
-
     def get_unique_records(self, stream, records):
         unique_records = set()
         for record in records:

--- a/tests/base.py
+++ b/tests/base.py
@@ -37,6 +37,9 @@ class MambuBaseTest(unittest.TestCase):
         """A set of expected stream names"""
         return set(self.expected_metadata().keys())
 
+    def expected_sync_streams(self):
+        return self.expected_streams() - self.untestable_streams()
+
     def expected_metadata(self):
         return {
             "branches": {

--- a/tests/base.py
+++ b/tests/base.py
@@ -397,31 +397,12 @@ class MambuBaseTest(unittest.TestCase):
                         if mdata.get('breadcrumb') == []:
                             self.assertFalse(mdata.get('metadata').get('selected'))
 
-    def select_and_verify_fields(self, conn_id, only_automatic=False):
+    def select_and_verify_fields(self, conn_id, select_all_fields = True):
         """
         Select all expected sync streams and fields.
 
         If only_automatic is true, only select automatic fields
         """
         catalogs = menagerie.get_catalogs(conn_id)
-        self.select_all_streams_and_fields(conn_id, catalogs)
+        self.select_all_streams_and_fields(conn_id, catalogs, select_all_fields = select_all_fields)
         self.verify_stream_and_field_selection(conn_id)
-
-    def make_connection_and_run_sync(self, create_connection_kwargs=None, selection_kwargs=None):
-        """
-        These lines of code are at the start of every test, and some tests repeat this logic a
-        second time
-        """
-        if create_connection_kwargs is None:
-            create_connection_kwargs = {}
-
-        if selection_kwargs is None:
-            selection_kwargs = {}
-
-        conn_id = self.create_connection(**create_connection_kwargs)
-        record_count = self.run_and_verify_sync(conn_id)
-        # ---------------------------------------------------------------------
-        bookmarks = menagerie.get_state(conn_id)
-        records = runner.get_records_from_target_output()
-
-        return conn_id, record_count, bookmarks, records

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,279 @@
+"""
+Setup expectations for test sub classes
+Run discovery for as a prerequisite for most tests
+"""
+import unittest
+import os
+
+from tap_tester import connections, menagerie, runner
+
+
+class MambuBaseTest(unittest.TestCase):
+    """
+    Setup expectations for test sub classes
+    Run discovery for as a prerequisite for most tests
+    """
+    AUTOMATIC_FIELDS = "automatic"
+    REPLICATION_KEYS = "valid-replication-keys"
+    PRIMARY_KEYS = "table-key-properties"
+    FOREIGN_KEYS = "table-foreign-key-properties"
+    REPLICATION_METHOD = "forced-replication-method"
+    API_LIMIT = "max-row-limit"
+    INCREMENTAL = "INCREMENTAL"
+    FULL_TABLE = "FULL_TABLE"
+    START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
+
+    @staticmethod
+    def tap_name():
+        """The name of the tap"""
+        return "tap-mambu"
+
+    @staticmethod
+    def get_type():
+        """the expected url route ending"""
+        return "platform.mambu"
+
+    def expected_streams(self):
+        """A set of expected stream names"""
+        return set(self.expected_metadata().keys())
+
+    def expected_metadata(self):
+        return {
+            "branches": {
+                self.PRIMARY_KEYS: {
+                    "id"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_modified_date"
+                }
+            },
+            "cards": {
+                self.PRIMARY_KEYS: {
+                    "deposit_id",
+                    "reference_token"
+                },
+                self.REPLICATION_METHOD: "FULL_TABLE",
+            },
+            "communications": {
+                self.PRIMARY_KEYS: {
+                    "encoded_key"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "creation_date"
+                }
+            },
+            "centres": {
+                self.PRIMARY_KEYS: {
+                    "id"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_modified_date"
+                }
+            },
+            "clients": {
+                self.PRIMARY_KEYS: {
+                    "id"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_modified_date"
+                }
+            },
+            "credit_arrangements": {
+                self.PRIMARY_KEYS: {
+                    "id"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_modified_date"
+                }
+            },
+            "custom_field_sets": {
+                self.PRIMARY_KEYS: {
+                    "id"
+                },
+                self.REPLICATION_METHOD: "FULL_TABLE",
+            },
+            "deposit_accounts": {
+                self.PRIMARY_KEYS: {
+                    "id"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_modified_date"
+                }
+            },
+            "deposit_products": {
+                self.PRIMARY_KEYS: {
+                    "id"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_modified_date"
+                }
+            },
+            "deposit_transactions": {
+                self.PRIMARY_KEYS: {
+                    "encoded_key"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "creation_date"
+                }
+            },
+            "groups": {
+                self.PRIMARY_KEYS: {
+                    "id"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_modified_date"
+                }
+            },
+            "loan_accounts": {
+                self.PRIMARY_KEYS: {
+                    "id"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_modified_date"
+                }
+            },
+            "loan_repayments": {
+                self.PRIMARY_KEYS: {
+                    "encoded_key"
+                },
+                self.REPLICATION_METHOD: "FULL_TABLE",
+            },
+            "loan_products": {
+                self.PRIMARY_KEYS: {
+                    "id"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_modified_date"
+                }
+            },
+            "loan_transactions": {
+                self.PRIMARY_KEYS: {
+                    "encoded_key"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "creation_date"
+                }
+            },
+            "tasks": {
+                self.PRIMARY_KEYS: {
+                    "id"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_modified_date"
+                }
+            },
+            "users": {
+                self.PRIMARY_KEYS: {
+                    "id"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_modified_date"
+                }
+            },
+            "gl_accounts": {
+                self.PRIMARY_KEYS: {
+                    "gl_code"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_modified_date"
+                }
+            },
+            "gl_journal_entries": {
+                self.PRIMARY_KEYS: {
+                    "entry_id"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "booking_date"
+                }
+            },
+            "activities": {
+                self.PRIMARY_KEYS: {
+                    "encoded_key"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "timestamp"
+                }
+            },
+            "index_rate_sources": {
+                self.PRIMARY_KEYS: {
+                    "encoded_key"
+                },
+                self.REPLICATION_METHOD: "FULL_TABLE",
+            },
+            "installments": {
+                self.PRIMARY_KEYS: {
+                    "encoded_key"
+                },
+                self.REPLICATION_METHOD: "INCREMENTAL",
+                self.REPLICATION_KEYS: {
+                    "last_paid_date"
+                }
+            }
+        }
+
+
+    def create_connection(self, original_properties: bool = True):
+        """Create a new connection with the test name"""
+        # Create the connection
+        conn_id = connections.ensure_connection(self, original_properties)
+
+        # Run a check job using orchestrator (discovery)
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        # Assert that the check job succeeded
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+        return conn_id
+
+    def get_properties(self):
+        return {
+            'start_date': '2020-10-01T00:00:00Z',
+            "username": os.environ['TAP_MAMBU_USERNAME'],
+            "subdomain": os.environ['TAP_MAMBU_SUBDOMAIN']
+            }
+
+    def get_credentials(self):
+        return {
+            "password": os.environ['TAP_MAMBU_PASSWORD']
+            }
+
+    def expected_primary_keys(self):
+        """
+        return a dictionary with key of table name
+        and value as a set of primary key fields
+        """
+        return {table: properties.get(self.PRIMARY_KEYS, set())
+                for table, properties
+                in self.expected_metadata().items()}
+
+    def expected_replication_keys(self):
+        """
+        return a dictionary with key of table name
+        and value as a set of replication key fields
+        """
+        return {table: properties.get(self.REPLICATION_KEYS, set())
+                for table, properties
+                in self.expected_metadata().items()}
+
+    def expected_replication_method(self):
+        """return a dictionary with key of table name nd value of replication method"""
+        return {table: properties.get(self.REPLICATION_METHOD, None)
+                for table, properties
+                in self.expected_metadata().items()}

--- a/tests/base.py
+++ b/tests/base.py
@@ -37,6 +37,9 @@ class MambuBaseTest(unittest.TestCase):
         """A set of expected stream names"""
         return set(self.expected_metadata().keys())
 
+    def untestable_streams(self):
+        return set()
+
     def expected_sync_streams(self):
         return self.expected_streams() - self.untestable_streams()
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -295,20 +295,20 @@ class MambuBaseTest(unittest.TestCase):
                 for table, properties
                 in self.expected_metadata().items()}
 
-    @staticmethod
-    def select_all_streams_and_fields(conn_id, catalogs, select_all_fields: bool = True):
+    def select_all_streams_and_fields(self, conn_id, catalogs, select_all_fields: bool = True):
         """Select all streams and all fields within streams"""
         for catalog in catalogs:
-            schema = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
+            if catalog["tap_stream_id"] in self.expected_sync_streams():
+                schema = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
 
-            non_selected_properties = []
-            if not select_all_fields:
-                # get a list of all properties so that none are selected
-                non_selected_properties = schema.get('annotated-schema', {}).get(
-                    'properties', {}).keys()
+                non_selected_properties = []
+                if not select_all_fields:
+                    # get a list of all properties so that none are selected
+                    non_selected_properties = schema.get('annotated-schema', {}).get(
+                        'properties', {}).keys()
 
-            connections.select_catalog_and_fields_via_metadata(
-                conn_id, catalog, schema, [], non_selected_properties)
+                    connections.select_catalog_and_fields_via_metadata(
+                        conn_id, catalog, schema, [], non_selected_properties)
 
     def verify_field_selection(self, conn_id, expected_stream_ids):
         """

--- a/tests/base.py
+++ b/tests/base.py
@@ -245,8 +245,9 @@ class MambuBaseTest(unittest.TestCase):
     def get_properties(self):
         return {
             'start_date': '2019-01-01T00:00:00Z',
-            "username": os.environ['TAP_MAMBU_USERNAME'],
-            "subdomain": os.environ['TAP_MAMBU_SUBDOMAIN']
+            'username': os.environ['TAP_MAMBU_USERNAME'],
+            'subdomain': os.environ['TAP_MAMBU_SUBDOMAIN'],
+            'page_size': '100'
             }
 
     def get_credentials(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -251,7 +251,7 @@ class MambuBaseTest(unittest.TestCase):
             'start_date': '2017-01-01T00:00:00Z',
             'username': os.environ['TAP_MAMBU_USERNAME'],
             'subdomain': os.environ['TAP_MAMBU_SUBDOMAIN'],
-            'page_size': 100
+            'page_size': '100'
         }
 
         if not original_properties:

--- a/tests/base.py
+++ b/tests/base.py
@@ -272,6 +272,14 @@ class MambuBaseTest(unittest.TestCase):
                 for table, properties
                 in self.expected_metadata().items()}
 
+    def expected_automatic_fields(self):
+        """
+        return a dictionary with key of table name and value as a set of
+        primary key and replication key fields
+        """
+        return {table : self.expected_primary_keys()[table] | self.expected_replication_keys()[table]
+                for table in self.expected_metadata().keys()}
+
     def expected_replication_method(self):
         """return a dictionary with key of table name nd value of replication method"""
         return {table: properties.get(self.REPLICATION_METHOD, None)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -61,8 +61,28 @@ class AutomaticFieldsTest(MambuBaseTest):
                             self.assertFalse(is_selected)
                             self.assertTrue(inclusion == 'available')
 
-        # Run a sync job using orchestrator
-        record_count_by_stream = self.run_and_verify_sync(conn_id)
+    def test_run(self):
+        """
+        Verify that we can get multiple pages of automatic fields for each
+        stream
+        """
+
+        # conn_id = self.create_connection()
+        # catalogs = menagerie.get_catalogs(conn_id)
+
+        # # Don't select any fields
+        # self.select_all_streams_and_fields(conn_id, catalogs, select_all_fields=False)
+
+        # self.verify_stream_and_field_selection(conn_id)
+
+        # # Run a sync job using orchestrator
+        # record_count_by_stream = self.run_and_verify_sync(conn_id)
+        (conn_id,
+         record_count_by_stream,
+         _,
+         _) = self.make_connection_and_run_sync(selection_kwargs={"select_all_fields": False})
+
+        actual_fields_by_stream = runner.examine_target_output_for_fields()
 
         # Assert all expected streams synced at least a full pages of records
         for stream in self.expected_sync_streams():
@@ -70,8 +90,6 @@ class AutomaticFieldsTest(MambuBaseTest):
                 self.assertGreater(record_count_by_stream.get(stream, 0),
                                    self.get_properties()['page_size'],
                                    msg="{} did not sync more than a page of records".format(stream))
-
-        actual_fields_by_stream = runner.examine_target_output_for_fields()
 
         for stream_name, actual_fields in actual_fields_by_stream.items():
             with self.subTest(stream=stream_name):

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -41,7 +41,7 @@ class AutomaticFieldsTest(MambuBaseTest):
         for stream in self.expected_sync_streams():
             with self.subTest(stream=stream):
                 self.assertGreater(record_count_by_stream.get(stream, 0),
-                                   self.get_properties()['page_size'],
+                                   int(self.get_properties()['page_size']),
                                    msg="{} did not sync more than a page of records".format(stream))
 
         for stream_name, actual_fields in actual_fields_by_stream.items():

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -1,7 +1,7 @@
 """
 Test that when no fields are selected for a stream, automatic fields are still replicated
 """
-from tap_tester import runner
+from tap_tester import runner, connections
 from base import MambuBaseTest
 
 class AutomaticFieldsTest(MambuBaseTest):
@@ -30,10 +30,13 @@ class AutomaticFieldsTest(MambuBaseTest):
         Verify that we can get multiple pages of automatic fields for each
         stream
         """
-        (_,
-         record_count_by_stream,
-         _,
-         _) = self.make_connection_and_run_sync(selection_kwargs={"select_all_fields": False})
+
+        conn_id = connections.ensure_connection(self)
+        self.run_and_verify_check_mode(conn_id)
+
+        self.select_and_verify_fields(conn_id, select_all_fields = False)
+
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
 
         actual_fields_by_stream = runner.examine_target_output_for_fields()
 

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -1,0 +1,79 @@
+"""
+Test that when no fields are selected for a stream, automatic fields are still replicated
+"""
+
+from tap_tester import runner, menagerie, connections
+
+from base import MambuBaseTest
+
+class AutomaticFieldsTest(MambuBaseTest):
+    """
+    Test that when no fields are selected for a stream, automatic fields
+    are still replicated
+    """
+
+    @staticmethod
+    def name():
+        return "tap_tester_mambu_automatic_fields_test"
+
+    def expected_sync_streams(self):
+        return self.expected_streams() - self.untestable_streams()
+
+    def untestable_streams(self):
+        return set([
+            "communications", # Need to set up Twilio or email server to send stuff
+        ])
+
+    def test_run(self):
+        """
+        Verify that we can get multiple pages of automatic fields for each
+        stream
+        """
+
+        conn_id = self.create_connection()
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        # Don't select any fields
+        for catalog_entry in catalogs:
+            if catalog_entry["tap_stream_id"] in self.expected_sync_streams():
+                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
+                connections.select_catalog_and_fields_via_metadata(
+                    conn_id,
+                    catalog_entry,
+                    schema,
+                    non_selected_fields=schema.get('annotated-schema', {}).get('properties', {})
+                )
+
+        # Verify that no fields are selected. Verify that automatic fields are automatic
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        for catalog_entry in catalogs:
+            if catalog_entry["tap_stream_id"] in self.expected_sync_streams():
+                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
+                entry_metadata = schema.get('metadata', [])
+
+                for mdata in entry_metadata:
+                    is_selected = mdata.get('metadata').get('selected')
+                    if mdata.get('breadcrumb') == []:
+                        self.assertTrue(is_selected)
+                    else:
+                        inclusion = mdata.get('metadata', {}).get('inclusion')
+                        field_name = mdata.get('breadcrumb', ['properties', None])[1]
+                        automatic_fields = self.expected_automatic_fields()[catalog_entry['tap_stream_id']]
+
+                        self.assertIsNotNone(field_name)
+
+                        if field_name in automatic_fields:
+                            self.assertTrue(inclusion == 'automatic')
+                        else:
+                            self.assertFalse(is_selected)
+
+        # Run a sync job using orchestrator
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
+
+        # Assert all expected streams synced at least
+        for stream in self.expected_sync_streams():
+            with self.subTest(stream=stream):
+                self.assertGreater(record_count_by_stream.get(stream, 0),
+                                   100,
+                                   msg="{} did not sync more than a page of records".format(stream))

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -16,9 +16,6 @@ class AutomaticFieldsTest(MambuBaseTest):
     def name():
         return "tap_tester_mambu_automatic_fields_test"
 
-    def expected_sync_streams(self):
-        return self.expected_streams() - self.untestable_streams()
-
     def untestable_streams(self):
         return set([
             "communications", # Need to set up Twilio or email server to send stuff

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -31,15 +31,7 @@ class AutomaticFieldsTest(MambuBaseTest):
         catalogs = menagerie.get_catalogs(conn_id)
 
         # Don't select any fields
-        for catalog_entry in catalogs:
-            if catalog_entry["tap_stream_id"] in self.expected_sync_streams():
-                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
-                connections.select_catalog_and_fields_via_metadata(
-                    conn_id,
-                    catalog_entry,
-                    schema,
-                    non_selected_fields=schema.get('annotated-schema', {}).get('properties', {})
-                )
+        self.select_all_streams_and_fields(conn_id, catalogs, select_all_fields=False)
 
         # For expected sync streams, verify that
         # - no fields are selected

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -30,17 +30,6 @@ class AutomaticFieldsTest(MambuBaseTest):
         Verify that we can get multiple pages of automatic fields for each
         stream
         """
-
-        # conn_id = self.create_connection()
-        # catalogs = menagerie.get_catalogs(conn_id)
-
-        # # Don't select any fields
-        # self.select_all_streams_and_fields(conn_id, catalogs, select_all_fields=False)
-
-        # self.verify_stream_and_field_selection(conn_id)
-
-        # # Run a sync job using orchestrator
-        # record_count_by_stream = self.run_and_verify_sync(conn_id)
         (_,
          record_count_by_stream,
          _,

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -21,22 +21,14 @@ class AutomaticFieldsTest(MambuBaseTest):
             "communications", # Need to set up Twilio or email server to send stuff
         ])
 
-    def test_run(self):
+    def verify_stream_and_field_selection(self, conn_id):
         """
-        Verify that we can get multiple pages of automatic fields for each
-        stream
+        For expected sync streams, verify that
+        - no fields are selected
+        - automatic fields are automatic
+        - non-automatic fields are "inclusion": "available"
         """
 
-        conn_id = self.create_connection()
-        catalogs = menagerie.get_catalogs(conn_id)
-
-        # Don't select any fields
-        self.select_all_streams_and_fields(conn_id, catalogs, select_all_fields=False)
-
-        # For expected sync streams, verify that
-        # - no fields are selected
-        # - automatic fields are automatic
-        # - non-automatic fields are "inclusion": "available"
         catalogs = menagerie.get_catalogs(conn_id)
 
         for catalog_entry in catalogs:

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -56,36 +56,8 @@ class BookmarksTest(MambuBaseTest):
         catalogs = menagerie.get_catalogs(conn_id)
 
         self.select_all_streams_and_fields(conn_id, catalogs)
+        self.verify_stream_and_field_selection(conn_id)
 
-        # For expected sync streams, verify that
-        # - all fields are selected
-        # - automatic fields are automatic
-        # - non-automatic fields are "inclusion": "available"
-        catalogs = menagerie.get_catalogs(conn_id)
-
-        for catalog_entry in catalogs:
-            tap_stream_id = catalog_entry['tap_stream_id']
-            if tap_stream_id in self.expected_sync_streams():
-                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
-                entry_metadata = schema.get('metadata', [])
-
-                for mdata in entry_metadata:
-                    is_selected = mdata.get('metadata').get('selected')
-                    if mdata.get('breadcrumb') == []:
-                        self.assertTrue(is_selected)
-                    else:
-                        inclusion = mdata.get('metadata', {}).get('inclusion')
-                        field_name = mdata.get('breadcrumb', ['properties', None])[1]
-
-                        automatic_fields = self.expected_automatic_fields()[tap_stream_id]
-
-                        self.assertIsNotNone(field_name)
-
-                        if field_name in automatic_fields:
-                            self.assertTrue(inclusion == 'automatic')
-                        else:
-                            self.assertTrue(is_selected)
-                            self.assertTrue(inclusion == 'available')
 
         # Run a sync job using orchestrator
         first_sync_record_count = self.run_and_verify_sync(conn_id)

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -1,0 +1,192 @@
+from tap_tester import runner, menagerie, connections
+
+from base import MambuBaseTest
+import singer
+from datetime import timedelta
+
+class BookmarksTest(MambuBaseTest):
+    """
+    Test that the tap can replicate multiple pages of data
+    """
+
+    @staticmethod
+    def name():
+        return "tap_tester_mambu_bookmarks_test"
+
+    def expected_sync_streams(self):
+        return self.expected_streams() - self.untestable_streams()
+
+    def untestable_streams(self):
+        return set([
+            "communications", # Need to set up Twilio or email server to send stuff
+            "installments",
+            "gl_accounts",
+        ])
+
+    def subtract_day(self, bookmark):
+        bookmark_dt = singer.utils.strptime_to_utc(bookmark)
+        adjusted_bookmark = bookmark_dt - timedelta(days=1)
+        return singer.utils.strftime(adjusted_bookmark)
+
+    def get_bookmark_key(self, stream):
+        stuff = {
+            "branches": "last_modified_date",
+            "communications": "creation_date",
+            "centres": "last_modified_date",
+            "clients": "last_modified_date",
+            "credit_arrangements": "last_modified_date",
+            "deposit_accounts": "last_modified_date",
+            "deposit_products": "last_modified_date",
+            "deposit_transactions": "creation_date",
+            "groups":"last_modified_date",
+            "loan_accounts": "last_modified_date",
+            "loan_products": "last_modified_date",
+            "loan_transactions": "creation_date",
+            "tasks": "last_modified_date",
+            "users": "last_modified_date",
+            "gl_journal_entries": "booking_date",
+            "activities": "timestamp",
+            "installments": "last_paid_date",
+        }
+        return stuff[stream]
+
+    def test_run(self):
+        """
+        Verify that we can get multiple pages of data for each stream
+        """
+
+        conn_id = self.create_connection()
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        # Select all fields
+        for catalog_entry in catalogs:
+            if catalog_entry["tap_stream_id"] in self.expected_sync_streams():
+                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
+                connections.select_catalog_and_fields_via_metadata(
+                    conn_id,
+                    catalog_entry,
+                    schema,
+                )
+
+        # For expected sync streams, verify that
+        # - all fields are selected
+        # - automatic fields are automatic
+        # - non-automatic fields are "inclusion": "available"
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        for catalog_entry in catalogs:
+            tap_stream_id = catalog_entry['tap_stream_id']
+            if tap_stream_id in self.expected_sync_streams():
+                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
+                entry_metadata = schema.get('metadata', [])
+
+                for mdata in entry_metadata:
+                    is_selected = mdata.get('metadata').get('selected')
+                    if mdata.get('breadcrumb') == []:
+                        self.assertTrue(is_selected)
+                    else:
+                        inclusion = mdata.get('metadata', {}).get('inclusion')
+                        field_name = mdata.get('breadcrumb', ['properties', None])[1]
+
+                        automatic_fields = self.expected_automatic_fields()[tap_stream_id]
+
+                        self.assertIsNotNone(field_name)
+
+                        if field_name in automatic_fields:
+                            self.assertTrue(inclusion == 'automatic')
+                        else:
+                            self.assertTrue(is_selected)
+                            self.assertTrue(inclusion == 'available')
+
+        # Run a sync job using orchestrator
+        first_sync_record_count = self.run_and_verify_sync(conn_id)
+
+        first_sync_state = menagerie.get_state(conn_id)
+        first_sync_bookmarks = dict(first_sync_state)
+        first_sync_records = runner.get_records_from_target_output()
+
+
+        new_bookmarks = {}
+        for stream_name, current_bookmark in first_sync_state['bookmarks'].items():
+            if stream_name == 'gl_accounts':
+                new_gl_bookmarks = {
+                    sub_stream : self.subtract_day(sub_bookmark)
+                    for sub_stream, sub_bookmark in current_bookmark.items()
+                }
+                new_bookmarks[stream_name] = new_gl_bookmarks
+            else:
+                new_bookmarks[stream_name] = self.subtract_day(current_bookmark)
+
+        new_state = {"bookmarks" : new_bookmarks}
+
+        menagerie.set_state(conn_id, new_state)
+
+        # Run a sync job using orchestrator
+        second_sync_record_count = self.run_and_verify_sync(conn_id)
+        second_sync_state = menagerie.get_state(conn_id)
+        second_sync_bookmarks = dict(second_sync_state)
+        second_sync_records = runner.get_records_from_target_output()
+
+        for stream in self.expected_sync_streams():
+            with self.subTest(stream=stream):
+                replication_method = self.expected_replication_method().get(stream)
+
+                # record counts
+                first_sync_count = first_sync_record_count.get(stream, 0)
+                second_sync_count = second_sync_record_count.get(stream, 0)
+
+                # record messages
+                first_sync_messages = first_sync_records.get(stream, {'messages': []}).get('messages')
+                second_sync_messages = second_sync_records.get(stream, {'messages': []}).get('messages')
+
+                if replication_method == self.INCREMENTAL:
+                    replication_key = self.expected_replication_keys().get(stream).pop()
+                    bookmark_key = self.get_bookmark_key(stream)  # BUG_SRCE-4609
+
+                    # bookmarked states (actual values)
+                    first_sync_bookmark_value = first_sync_bookmarks['bookmarks'][stream]
+                    second_sync_bookmark_value = second_sync_bookmarks['bookmarks'][stream]
+                    # bookmarked values as utc for comparing against records
+                    first_sync_bookmark_value_utc = singer.utils.strptime_to_utc(first_sync_bookmark_value)
+                    second_sync_bookmark_value_utc = singer.utils.strptime_to_utc(second_sync_bookmark_value)
+
+                    simulated_bookmark_value = new_state['bookmarks'][stream]
+
+                    # Verify the second sync bookmark is Equal to the first sync bookmark
+                    self.assertEqual(second_sync_bookmark_value, first_sync_bookmark_value) # assumes no changes to data during test
+
+                    # Verify the first sync bookmark value is the max replication key value for a given stream
+                    for message in first_sync_messages:
+                        replication_key_value = message.get('data').get(replication_key)
+                        self.assertLessEqual(singer.utils.strptime_to_utc(replication_key_value),
+                                             first_sync_bookmark_value_utc,
+                                             msg="First sync bookmark was set incorrectly, a record with a greater rep key value was synced")
+
+                    for message in second_sync_messages:
+                        replication_key_value = message.get('data').get(replication_key)
+
+                        # Verify the second sync records respect the previous (simulated) bookmark value
+                        self.assertGreaterEqual(singer.utils.strptime_to_utc(replication_key_value),
+                                                singer.utils.strptime_to_utc(simulated_bookmark_value),
+                                                msg="Second sync records do not repect the previous bookmark.")
+
+                        # Verify the second sync bookmark value is the max replication key value for a given stream
+                        self.assertLessEqual(singer.utils.strptime_to_utc(replication_key_value),
+                                             second_sync_bookmark_value_utc,
+                                             msg="Second sync bookmark was set incorrectly, a record with a greater rep key value was synced")
+
+                    # Verify the number of records in the 2nd sync is less then the first
+                    self.assertLess(second_sync_count, first_sync_count)
+
+                    # Verify at least 1 record was replicated in the second sync
+                    self.assertGreater(second_sync_count, 0, msg="We are not fully testing bookmarking for {}".format(stream))
+
+                elif replication_method == self.FULL_TABLE:
+                    # Verify the first sync sets a bookmark of the expected form
+                    self.assertNotIn(stream, first_sync_bookmarks['bookmarks'])
+
+                    # Verify the second sync sets a bookmark of the expected form
+                    self.assertNotIn(stream, second_sync_bookmarks['bookmarks'])
+
+                else:
+                    raise NotImplementedError("invalid replication method: {}".format(replication_method))

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -30,17 +30,22 @@ class BookmarksTest(MambuBaseTest):
         Verify that we can get multiple pages of data for each stream
         """
 
-        conn_id = self.create_connection()
-        catalogs = menagerie.get_catalogs(conn_id)
+        # conn_id = self.create_connection()
+        # catalogs = menagerie.get_catalogs(conn_id)
 
-        self.select_all_streams_and_fields(conn_id, catalogs)
-        self.verify_stream_and_field_selection(conn_id)
+        # self.select_all_streams_and_fields(conn_id, catalogs)
+        # self.verify_stream_and_field_selection(conn_id)
 
-        # Run a sync job using orchestrator
-        first_sync_record_count = self.run_and_verify_sync(conn_id)
+        # # Run a sync job using orchestrator
+        # first_sync_record_count = self.run_and_verify_sync(conn_id)
 
-        first_sync_bookmarks = menagerie.get_state(conn_id)
-        first_sync_records = runner.get_records_from_target_output()
+        # first_sync_bookmarks = menagerie.get_state(conn_id)
+        # first_sync_records = runner.get_records_from_target_output()
+
+        (conn_id,
+         first_sync_record_count,
+         first_sync_bookmarks,
+         first_sync_records) = self.make_connection_and_run_sync()
 
 
         new_bookmarks = {}

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -13,9 +13,6 @@ class BookmarksTest(MambuBaseTest):
     def name():
         return "tap_tester_mambu_bookmarks_test"
 
-    def expected_sync_streams(self):
-        return self.expected_streams() - self.untestable_streams()
-
     def untestable_streams(self):
         return set([
             "communications", # Need to set up Twilio or email server to send stuff

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -40,13 +40,12 @@ class BookmarksTest(MambuBaseTest):
         # Run a sync job using orchestrator
         first_sync_record_count = self.run_and_verify_sync(conn_id)
 
-        first_sync_state = menagerie.get_state(conn_id)
-        first_sync_bookmarks = dict(first_sync_state)
+        first_sync_bookmarks = menagerie.get_state(conn_id)
         first_sync_records = runner.get_records_from_target_output()
 
 
         new_bookmarks = {}
-        for stream_name, current_bookmark in first_sync_state['bookmarks'].items():
+        for stream_name, current_bookmark in first_sync_bookmarks['bookmarks'].items():
             if stream_name == 'gl_accounts':
                 new_gl_bookmarks = {
                     sub_stream : self.subtract_day(sub_bookmark)
@@ -62,8 +61,7 @@ class BookmarksTest(MambuBaseTest):
 
         # Run a sync job using orchestrator
         second_sync_record_count = self.run_and_verify_sync(conn_id)
-        second_sync_state = menagerie.get_state(conn_id)
-        second_sync_bookmarks = dict(second_sync_state)
+        second_sync_bookmarks = menagerie.get_state(conn_id)
         second_sync_records = runner.get_records_from_target_output()
 
         for stream in self.expected_sync_streams():

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -31,19 +31,6 @@ class BookmarksTest(MambuBaseTest):
         """
         Verify that we can get multiple pages of data for each stream
         """
-
-        # conn_id = self.create_connection()
-        # catalogs = menagerie.get_catalogs(conn_id)
-
-        # self.select_all_streams_and_fields(conn_id, catalogs)
-        # self.verify_stream_and_field_selection(conn_id)
-
-        # # Run a sync job using orchestrator
-        # first_sync_record_count = self.run_and_verify_sync(conn_id)
-
-        # first_sync_bookmarks = menagerie.get_state(conn_id)
-        # first_sync_records = runner.get_records_from_target_output()
-
         (conn_id,
          first_sync_record_count,
          first_sync_bookmarks,

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -25,28 +25,6 @@ class BookmarksTest(MambuBaseTest):
         adjusted_bookmark = bookmark_dt - timedelta(days=1)
         return singer.utils.strftime(adjusted_bookmark)
 
-    def get_bookmark_key(self, stream):
-        stuff = {
-            "branches": "last_modified_date",
-            "communications": "creation_date",
-            "centres": "last_modified_date",
-            "clients": "last_modified_date",
-            "credit_arrangements": "last_modified_date",
-            "deposit_accounts": "last_modified_date",
-            "deposit_products": "last_modified_date",
-            "deposit_transactions": "creation_date",
-            "groups":"last_modified_date",
-            "loan_accounts": "last_modified_date",
-            "loan_products": "last_modified_date",
-            "loan_transactions": "creation_date",
-            "tasks": "last_modified_date",
-            "users": "last_modified_date",
-            "gl_journal_entries": "booking_date",
-            "activities": "timestamp",
-            "installments": "last_paid_date",
-        }
-        return stuff[stream]
-
     def test_run(self):
         """
         Verify that we can get multiple pages of data for each stream
@@ -102,7 +80,6 @@ class BookmarksTest(MambuBaseTest):
 
                 if replication_method == self.INCREMENTAL:
                     replication_key = self.expected_replication_keys().get(stream).pop()
-                    bookmark_key = self.get_bookmark_key(stream)  # BUG_SRCE-4609
 
                     # bookmarked states (actual values)
                     first_sync_bookmark_value = first_sync_bookmarks['bookmarks'][stream]

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -55,15 +55,7 @@ class BookmarksTest(MambuBaseTest):
         conn_id = self.create_connection()
         catalogs = menagerie.get_catalogs(conn_id)
 
-        # Select all fields
-        for catalog_entry in catalogs:
-            if catalog_entry["tap_stream_id"] in self.expected_sync_streams():
-                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
-                connections.select_catalog_and_fields_via_metadata(
-                    conn_id,
-                    catalog_entry,
-                    schema,
-                )
+        self.select_all_streams_and_fields(conn_id, catalogs)
 
         # For expected sync streams, verify that
         # - all fields are selected

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -1,8 +1,8 @@
 """
 Test that the tap can replicate multiple pages of data
 """
-import backoff
 from datetime import timedelta
+import backoff
 from singer.utils import strftime, strptime_to_utc
 from tap_tester import connections, menagerie, runner
 from base import MambuBaseTest

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,154 @@
+"""
+Test tap discovery
+"""
+import re
+
+from tap_tester import menagerie, connections, runner
+
+from base import MambuBaseTest
+
+class DiscoveryTest(MambuBaseTest):
+    """ Test the tap discovery """
+
+    @staticmethod
+    def name():
+        return "tap_tester_mambu_discovery_test"
+
+    def test_run(self):
+        """
+        • Verify that discover creates the appropriate catalog, schema, metadata, etc.
+        • Verify number of actual streams discovered match expected
+        • Verify the stream names discovered were what we expect
+        • Verify stream names follow naming convention
+          • streams should only have lowercase alphas and underscores
+        • verify there is only 1 top level breadcrumb
+        • verify replication key(s)
+        • verify primary key(s)
+        • verify that if there is a replication key we are doing INCREMENTAL otherwise FULL_TABLE
+        • verify the actual replication matches our expected replication method
+        • verify that primary and replication keys are given the inclusion of automatic metadata
+        • verify that all other fields have inclusion of available metadata
+        """
+        streams_to_test = self.expected_streams()
+
+        conn_id = self.create_connection()
+
+        # Verify number of actual streams discovered match expected
+        catalogs = menagerie.get_catalogs(conn_id)
+        found_catalogs = [catalog for catalog in catalogs
+                          if catalog.get('tap_stream_id') in streams_to_test]
+
+        self.assertGreater(len(found_catalogs), 0,
+                           msg="unable to locate schemas for connection {}".format(conn_id))
+        self.assertEqual(len(found_catalogs),
+                         len(streams_to_test),
+                         msg="Expected {} streams, actual was {} for connection {}, "
+                             "actual {}".format(
+                                 len(streams_to_test),
+                                 len(found_catalogs),
+                                 found_catalogs,
+                                 conn_id))
+
+        # Verify the stream names discovered were what we expect
+        found_catalog_names = {c['tap_stream_id'] for c in found_catalogs}
+        self.assertEqual(set(streams_to_test),
+                         set(found_catalog_names),
+                         msg="Expected streams don't match actual streams")
+
+        # Verify stream names follow naming convention
+        # streams should only have lowercase alphas and underscores
+        self.assertTrue(all([re.fullmatch(r"[a-z_]+", name) for name in found_catalog_names]),
+                        msg="One or more streams don't follow standard naming")
+
+        for stream in streams_to_test:
+            with self.subTest(stream=stream):
+                catalog = next(iter([catalog for catalog in found_catalogs
+                                     if catalog["stream_name"] == stream]))
+                assert catalog  # based on previous tests this should always be found
+
+                schema_and_metadata = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
+                metadata = schema_and_metadata["metadata"]
+                schema = schema_and_metadata["annotated-schema"]
+
+                # verify the stream level properties are as expected
+
+                # verify there is only 1 top level breadcrumb
+                stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+                self.assertTrue(len(stream_properties) == 1,
+                                msg=("There is NOT only one top level breadcrumb for {}"
+                                "\nstream_properties | {}").format(stream, stream_properties))
+
+                # verify replication key(s)
+                expected = self.expected_replication_keys()[stream]
+                actual = set(
+                    stream_properties[0].get("metadata", {}).get(self.REPLICATION_KEYS, [])
+                )
+
+                self.assertEqual(
+                    expected,
+                    actual,
+                    msg="expected replication key {} but actual is {}".format(expected, actual))
+
+                # verify primary key(s)
+                expected = self.expected_primary_keys()[stream]
+                actual = set(
+                    stream_properties[0].get("metadata", {}).get(self.PRIMARY_KEYS, [])
+                )
+
+                self.assertEqual(
+                    expected,
+                    actual,
+                    msg="expected primary key {} but actual is {}".format(expected, actual))
+
+                # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
+
+
+                actual_replication_method = (
+                    stream_properties[0]
+                    .get("metadata", {})
+                    .get(self.REPLICATION_METHOD)
+                )
+
+                if stream_properties[0].get("metadata", {}).get(self.REPLICATION_KEYS):
+                    self.assertTrue(
+                        self.INCREMENTAL == actual_replication_method,
+                        msg="Expected INCREMENTAL replication since there is a replication key")
+                else:
+                    self.assertTrue(
+                        self.FULL_TABLE == actual_replication_method,
+                        msg="Expected FULL_TABLE replication since there is no replication key")
+
+                # verify the actual replication matches our expected replication method
+                expected_replication_method = self.expected_replication_method().get(stream, None)
+                self.assertEqual(
+                    expected_replication_method,
+                    actual_replication_method,
+                    msg="expected primary key {} but actual is {}".format(
+                        expected_replication_method,
+                        actual_replication_method))
+
+                expected_primary_keys = self.expected_primary_keys()[stream]
+                expected_replication_keys = self.expected_replication_keys()[stream]
+                expected_automatic_fields = expected_primary_keys | expected_replication_keys
+
+                # verify that primary, replication and foreign keys
+                # are given the inclusion of automatic in metadata.
+
+                for item in metadata:
+                    # Skip the stream level metadata
+                    if item.get("breadcrumb") == []:
+                        continue
+
+                    actual_field_inclusion = item.get("metadata", {}).get("inclusion")
+                    field_name = item.get("breadcrumb", ["properties", None])[1]
+
+                    if field_name:
+                        if actual_field_inclusion == "automatic":
+                            self.assertIn(field_name, expected_automatic_fields)
+                        elif actual_field_inclusion == "available":
+                            self.assertNotIn(field_name, expected_automatic_fields)
+                        else:
+                            raise RuntimeError("Stream {} got unexpected `inclusion` value {}"
+                                               .format(stream_name, field_name))
+                    else:
+                        raise RuntimeError("Got null field name on stream".format(stream_name))

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -2,7 +2,7 @@
 Test tap discovery
 """
 import re
-from tap_tester import menagerie
+from tap_tester import connections, menagerie
 from base import MambuBaseTest
 
 class DiscoveryTest(MambuBaseTest):
@@ -29,7 +29,8 @@ class DiscoveryTest(MambuBaseTest):
         """
         streams_to_test = self.expected_streams()
 
-        conn_id = self.create_connection()
+        conn_id = connections.ensure_connection(self)
+        self.run_and_verify_check_mode(conn_id)
 
         # Verify number of actual streams discovered match expected
         catalogs = menagerie.get_catalogs(conn_id)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -3,7 +3,7 @@ Test tap discovery
 """
 import re
 
-from tap_tester import menagerie, connections, runner
+from tap_tester import menagerie
 
 from base import MambuBaseTest
 
@@ -68,7 +68,6 @@ class DiscoveryTest(MambuBaseTest):
 
                 schema_and_metadata = menagerie.get_annotated_schema(conn_id, catalog['stream_id'])
                 metadata = schema_and_metadata["metadata"]
-                schema = schema_and_metadata["annotated-schema"]
 
                 # verify the stream level properties are as expected
 
@@ -149,6 +148,6 @@ class DiscoveryTest(MambuBaseTest):
                             self.assertNotIn(field_name, expected_automatic_fields)
                         else:
                             raise RuntimeError("Stream {} got unexpected `inclusion` value {}"
-                                               .format(stream_name, field_name))
+                                               .format(stream, field_name))
                     else:
-                        raise RuntimeError("Got null field name on stream".format(stream_name))
+                        raise RuntimeError("Got null field name on stream {}".format(stream))

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -28,12 +28,14 @@ class PaginationTest(MambuBaseTest):
          _,
          all_records_by_stream) = self.make_connection_and_run_sync()
 
+        page_size = int(self.get_properties()['page_size'])
+
         for stream in self.expected_sync_streams():
             with self.subTest(stream=stream):
                 # Assert all expected streams synced at least a full pages of records
                 self.assertGreater(
                     record_count_by_stream.get(stream, 0),
-                    self.get_properties()['page_size'],
+                    page_size,
                     msg="{} did not sync more than a page of records".format(stream)
                 )
 
@@ -43,4 +45,4 @@ class PaginationTest(MambuBaseTest):
                 unique_records = self.get_unique_records(stream, records)
 
                 self.assertGreater(len(unique_records),
-                                   self.get_properties()['page_size'])
+                                   page_size)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -44,8 +44,6 @@ class PaginationTest(MambuBaseTest):
                     msg="{} did not sync more than a page of records".format(stream)
                 )
 
-                # Assert that records are unique
-
                 records = [ x['data'] for x in all_records_by_stream[stream]['messages']]
 
                 unique_records = self.get_unique_records(stream, records)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -23,17 +23,6 @@ class PaginationTest(MambuBaseTest):
         Verify that we can get multiple pages of unique records for each
         stream
         """
-
-        # conn_id = self.create_connection()
-        # catalogs = menagerie.get_catalogs(conn_id)
-
-        # self.select_all_streams_and_fields(conn_id, catalogs)
-        # self.verify_stream_and_field_selection(conn_id)
-
-        # # Run a sync job using orchestrator
-        # record_count_by_stream = self.run_and_verify_sync(conn_id)
-        # all_records_by_stream = runner.get_records_from_target_output()
-
         (_,
          record_count_by_stream,
          _,
@@ -49,10 +38,7 @@ class PaginationTest(MambuBaseTest):
                 )
 
                 # Assert that records are unique
-                records = self.filter_output_file_for_records(
-                    all_records_by_stream,
-                    stream
-                )
+                records = self.filter_output_file_for_records(all_records_by_stream, stream)
 
                 unique_records = self.get_unique_records(stream, records)
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -2,8 +2,6 @@
 Test that when no fields are selected for a stream, automatic fields are still replicated
 """
 
-from tap_tester import runner, menagerie, connections
-
 from base import MambuBaseTest
 
 class PaginationTest(MambuBaseTest):
@@ -36,7 +34,7 @@ class PaginationTest(MambuBaseTest):
         # record_count_by_stream = self.run_and_verify_sync(conn_id)
         # all_records_by_stream = runner.get_records_from_target_output()
 
-        (conn_id,
+        (_,
          record_count_by_stream,
          _,
          all_records_by_stream) = self.make_connection_and_run_sync()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -86,19 +86,13 @@ class PaginationTest(MambuBaseTest):
                     msg="{} did not sync more than a page of records".format(stream)
                 )
 
-
                 # Assert that records are unique
-                records = [message['data']
-                           for message in all_records_by_stream[stream]['messages']
-                           if message['action'] == 'upsert']
+                records = self.filter_output_file_for_records(
+                    all_records_by_stream,
+                    stream
+                )
 
-                unique_records = set()
-                for record in records:
-                    # Build the primary key for this record, maintaining the same order for the fields
-                    record_primary_key = [record[field]
-                                          for field in sorted(self.expected_primary_keys()[stream])]
-                    # Cast to a tuple to make it hashable
-                    unique_records.add(tuple(record_primary_key))
+                unique_records = self.get_unique_records(stream, records)
 
                 self.assertGreater(len(unique_records),
                                    self.get_properties()['page_size'])

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -26,15 +26,20 @@ class PaginationTest(MambuBaseTest):
         stream
         """
 
-        conn_id = self.create_connection()
-        catalogs = menagerie.get_catalogs(conn_id)
+        # conn_id = self.create_connection()
+        # catalogs = menagerie.get_catalogs(conn_id)
 
-        self.select_all_streams_and_fields(conn_id, catalogs)
-        self.verify_stream_and_field_selection(conn_id)
+        # self.select_all_streams_and_fields(conn_id, catalogs)
+        # self.verify_stream_and_field_selection(conn_id)
 
-        # Run a sync job using orchestrator
-        record_count_by_stream = self.run_and_verify_sync(conn_id)
-        all_records_by_stream = runner.get_records_from_target_output()
+        # # Run a sync job using orchestrator
+        # record_count_by_stream = self.run_and_verify_sync(conn_id)
+        # all_records_by_stream = runner.get_records_from_target_output()
+
+        (conn_id,
+         record_count_by_stream,
+         _,
+         all_records_by_stream) = self.make_connection_and_run_sync()
 
         for stream in self.expected_sync_streams():
             with self.subTest(stream=stream):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,104 @@
+"""
+Test that when no fields are selected for a stream, automatic fields are still replicated
+"""
+
+from tap_tester import runner, menagerie, connections
+
+from base import MambuBaseTest
+
+class PaginationTest(MambuBaseTest):
+    """
+    Test that the tap can paginate API endpoints
+    """
+
+    @staticmethod
+    def name():
+        return "tap_tester_mambu_pagination_test"
+
+    def expected_sync_streams(self):
+        return self.expected_streams() - self.untestable_streams()
+
+    def untestable_streams(self):
+        return set([
+            "communications", # Need to set up Twilio or email server to send stuff
+        ])
+
+    def test_run(self):
+        """
+        Verify that we can get multiple pages of unique records for each
+        stream
+        """
+
+        conn_id = self.create_connection()
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        # Select all fields
+        for catalog_entry in catalogs:
+            if catalog_entry["tap_stream_id"] in self.expected_sync_streams():
+                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
+                connections.select_catalog_and_fields_via_metadata(
+                    conn_id,
+                    catalog_entry,
+                    schema,
+                )
+
+        # For expected sync streams, verify that
+        # - all fields are selected
+        # - automatic fields are automatic
+        # - non-automatic fields are "inclusion": "available"
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        for catalog_entry in catalogs:
+            tap_stream_id = catalog_entry['tap_stream_id']
+            if tap_stream_id in self.expected_sync_streams():
+                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
+                entry_metadata = schema.get('metadata', [])
+
+                for mdata in entry_metadata:
+                    is_selected = mdata.get('metadata').get('selected')
+                    if mdata.get('breadcrumb') == []:
+                        self.assertTrue(is_selected)
+                    else:
+                        inclusion = mdata.get('metadata', {}).get('inclusion')
+                        field_name = mdata.get('breadcrumb', ['properties', None])[1]
+
+                        automatic_fields = self.expected_automatic_fields()[tap_stream_id]
+
+                        self.assertIsNotNone(field_name)
+
+                        if field_name in automatic_fields:
+                            self.assertTrue(inclusion == 'automatic')
+                        else:
+                            self.assertTrue(is_selected)
+                            self.assertTrue(inclusion == 'available')
+
+        # Run a sync job using orchestrator
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
+        all_records_by_stream = runner.get_records_from_target_output()
+
+
+        for stream in self.expected_sync_streams():
+            with self.subTest(stream=stream):
+                # Assert all expected streams synced at least a full pages of records
+                self.assertGreater(
+                    record_count_by_stream.get(stream, 0),
+                    self.get_properties()['page_size'],
+                    msg="{} did not sync more than a page of records".format(stream)
+                )
+
+
+                # Assert that records are unique
+                records = [message['data']
+                           for message in all_records_by_stream[stream]['messages']
+                           if message['action'] == 'upsert']
+
+                unique_records = set()
+                for record in records:
+                    # Build the primary key for this record, maintaining the same order for the fields
+                    record_primary_key = [record[field]
+                                          for field in sorted(self.expected_primary_keys()[stream])]
+                    # Cast to a tuple to make it hashable
+                    unique_records.add(tuple(record_primary_key))
+
+                self.assertGreater(len(unique_records),
+                                   self.get_properties()['page_size'])

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -36,7 +36,6 @@ class PaginationTest(MambuBaseTest):
         record_count_by_stream = self.run_and_verify_sync(conn_id)
         all_records_by_stream = runner.get_records_from_target_output()
 
-
         for stream in self.expected_sync_streams():
             with self.subTest(stream=stream):
                 # Assert all expected streams synced at least a full pages of records

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -29,15 +29,7 @@ class PaginationTest(MambuBaseTest):
         conn_id = self.create_connection()
         catalogs = menagerie.get_catalogs(conn_id)
 
-        # Select all fields
-        for catalog_entry in catalogs:
-            if catalog_entry["tap_stream_id"] in self.expected_sync_streams():
-                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
-                connections.select_catalog_and_fields_via_metadata(
-                    conn_id,
-                    catalog_entry,
-                    schema,
-                )
+        self.select_all_streams_and_fields(conn_id, catalogs)
 
         # For expected sync streams, verify that
         # - all fields are selected

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -15,9 +15,6 @@ class PaginationTest(MambuBaseTest):
     def name():
         return "tap_tester_mambu_pagination_test"
 
-    def expected_sync_streams(self):
-        return self.expected_streams() - self.untestable_streams()
-
     def untestable_streams(self):
         return set([
             "communications", # Need to set up Twilio or email server to send stuff

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -30,36 +30,7 @@ class PaginationTest(MambuBaseTest):
         catalogs = menagerie.get_catalogs(conn_id)
 
         self.select_all_streams_and_fields(conn_id, catalogs)
-
-        # For expected sync streams, verify that
-        # - all fields are selected
-        # - automatic fields are automatic
-        # - non-automatic fields are "inclusion": "available"
-        catalogs = menagerie.get_catalogs(conn_id)
-
-        for catalog_entry in catalogs:
-            tap_stream_id = catalog_entry['tap_stream_id']
-            if tap_stream_id in self.expected_sync_streams():
-                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
-                entry_metadata = schema.get('metadata', [])
-
-                for mdata in entry_metadata:
-                    is_selected = mdata.get('metadata').get('selected')
-                    if mdata.get('breadcrumb') == []:
-                        self.assertTrue(is_selected)
-                    else:
-                        inclusion = mdata.get('metadata', {}).get('inclusion')
-                        field_name = mdata.get('breadcrumb', ['properties', None])[1]
-
-                        automatic_fields = self.expected_automatic_fields()[tap_stream_id]
-
-                        self.assertIsNotNone(field_name)
-
-                        if field_name in automatic_fields:
-                            self.assertTrue(inclusion == 'automatic')
-                        else:
-                            self.assertTrue(is_selected)
-                            self.assertTrue(inclusion == 'available')
+        self.verify_stream_and_field_selection(conn_id)
 
         # Run a sync job using orchestrator
         record_count_by_stream = self.run_and_verify_sync(conn_id)

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -1,0 +1,233 @@
+"""
+Test that the tap respects the start date
+"""
+
+from tap_tester import runner, menagerie, connections
+
+from base import MambuBaseTest
+import singer
+
+class StartDateTest(MambuBaseTest):
+    """
+    Test that the tap respects the start date
+    """
+
+    first_sync_start_date = None
+    second_sync_start_date = None
+    first_sync_records = None
+    second_sync_records = None
+
+    @staticmethod
+    def name():
+        return "tap_tester_mambu_start_date_test"
+
+    def setUp(self):
+        self.first_sync_start_date = self.get_properties()['start_date']
+
+        self.second_sync_start_date = self.get_properties(
+            original_properties=False
+        )['start_date']
+
+    def expected_sync_streams(self):
+        return self.expected_streams() - self.untestable_streams()
+
+    def untestable_streams(self):
+        return set([
+            "communications", # Need to set up Twilio or email server to send stuff
+            "installments",
+        ])
+
+    def get_replication_key_values(self, stream, records):
+        all_records = []
+        for record in records:
+            # Build the primary key for this record, maintaining the same order for the fields
+            record_rep_key = [record[field]
+                              for field in sorted(self.expected_replication_keys()[stream])]
+            # Cast to a tuple to make it hashable
+            all_records.append(record_rep_key[0])
+        return all_records
+
+    def do_verify_replication_key_values(self, stream_name, records, start_date):
+        rep_values = self.get_replication_key_values(stream_name, records)
+
+        for value in rep_values:
+            self.assertGreaterEqual(
+                singer.utils.strptime_to_utc(value),
+                singer.utils.strptime_to_utc(start_date)
+            )
+
+    def verify_replication_key_values(self, stream_name):
+        self.do_verify_replication_key_values(
+            stream_name,
+            self.first_sync_records,
+            self.first_sync_start_date
+        )
+        self.do_verify_replication_key_values(
+            stream_name,
+            self.second_sync_records,
+            self.second_sync_start_date
+        )
+
+    def test_run(self):
+        """
+        Verify that running a sync, then moving the start date into the
+        future and running a sync results in less records than the first
+        sync
+        """
+
+        conn_id = self.create_connection()
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        # Select all fields
+        for catalog_entry in catalogs:
+            if catalog_entry["tap_stream_id"] in self.expected_sync_streams():
+                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
+                connections.select_catalog_and_fields_via_metadata(
+                    conn_id,
+                    catalog_entry,
+                    schema,
+                )
+
+        # For expected sync streams, verify that
+        # - all fields are selected
+        # - automatic fields are automatic
+        # - non-automatic fields are "inclusion": "available"
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        for catalog_entry in catalogs:
+            tap_stream_id = catalog_entry['tap_stream_id']
+            if tap_stream_id in self.expected_sync_streams():
+                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
+                entry_metadata = schema.get('metadata', [])
+
+                for mdata in entry_metadata:
+                    is_selected = mdata.get('metadata').get('selected')
+                    if mdata.get('breadcrumb') == []:
+                        self.assertTrue(is_selected)
+                    else:
+                        inclusion = mdata.get('metadata', {}).get('inclusion')
+                        field_name = mdata.get('breadcrumb', ['properties', None])[1]
+
+                        automatic_fields = self.expected_automatic_fields()[tap_stream_id]
+
+                        self.assertIsNotNone(field_name)
+
+                        if field_name in automatic_fields:
+                            self.assertTrue(inclusion == 'automatic')
+                        else:
+                            self.assertTrue(is_selected)
+                            self.assertTrue(inclusion == 'available')
+
+        # Run a sync job using orchestrator
+        first_sync_record_count_by_stream = self.run_and_verify_sync(conn_id)
+        first_sync_state = menagerie.get_state(conn_id)
+        first_sync_all_records_by_stream = runner.get_records_from_target_output()
+
+        conn_id = self.create_connection(original_properties=False)
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        # Select all fields
+        for catalog_entry in catalogs:
+            if catalog_entry["tap_stream_id"] in self.expected_sync_streams():
+                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
+                connections.select_catalog_and_fields_via_metadata(
+                    conn_id,
+                    catalog_entry,
+                    schema,
+                )
+
+        # For expected sync streams, verify that
+        # - all fields are selected
+        # - automatic fields are automatic
+        # - non-automatic fields are "inclusion": "available"
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        for catalog_entry in catalogs:
+            tap_stream_id = catalog_entry['tap_stream_id']
+            if tap_stream_id in self.expected_sync_streams():
+                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
+                entry_metadata = schema.get('metadata', [])
+
+                for mdata in entry_metadata:
+                    is_selected = mdata.get('metadata').get('selected')
+                    if mdata.get('breadcrumb') == []:
+                        self.assertTrue(is_selected)
+                    else:
+                        inclusion = mdata.get('metadata', {}).get('inclusion')
+                        field_name = mdata.get('breadcrumb', ['properties', None])[1]
+
+                        automatic_fields = self.expected_automatic_fields()[tap_stream_id]
+
+                        self.assertIsNotNone(field_name)
+
+                        if field_name in automatic_fields:
+                            self.assertTrue(inclusion == 'automatic')
+                        else:
+                            self.assertTrue(is_selected)
+                            self.assertTrue(inclusion == 'available')
+
+        # Run a sync job using orchestrator
+        second_sync_record_count_by_stream = self.run_and_verify_sync(conn_id)
+        second_sync_state = menagerie.get_state(conn_id)
+        second_sync_all_records_by_stream = runner.get_records_from_target_output()
+
+        all_metadata = self.expected_metadata()
+
+        for stream_name in self.expected_sync_streams():
+            stream_metadata = all_metadata[stream_name]
+            with self.subTest(stream=stream_name):
+
+                replication_method = stream_metadata.get(self.REPLICATION_METHOD)
+
+                first_sync_count = first_sync_record_count_by_stream.get(stream_name,0)
+                second_sync_count = second_sync_record_count_by_stream.get(stream_name,0)
+
+                self.first_sync_records = self.filter_output_file_for_records(
+                    first_sync_all_records_by_stream,
+                    stream_name
+                )
+
+                self.second_sync_records = self.filter_output_file_for_records(
+                    second_sync_all_records_by_stream,
+                    stream_name
+                )
+
+                if  replication_method == self.FULL_TABLE:
+                    """
+                    Testing Criteria:
+                    1. Verify that Sync B includes the same number of records as Sync A
+                    2. Verify the saved state following each sync does not contain a bookmark value
+                       for the stream.
+                    3. Verify that all records in Sync B are included in Sync A.
+                    """
+                    # Criteria 1
+                    self.assertEqual(first_sync_count, second_sync_count)
+
+                    # Criteria 2
+                    self.assertNotIn(stream_name, first_sync_state['bookmarks'])
+                    self.assertNotIn(stream_name, second_sync_state['bookmarks'])
+
+                    # Criteria 3
+                    first_sync_unique_records = self.get_unique_records(stream_name,
+                                                                        self.first_sync_records)
+                    second_sync_unique_records = self.get_unique_records(stream_name,
+                                                                         self.second_sync_records)
+                    self.assertSetEqual(first_sync_unique_records, second_sync_unique_records)
+                else:
+                    """
+                    Testing Criteria:
+                    1. Verify the saved state following each sync contains an appropriate bookmark
+                       value that corresponds to the stream’s replication key.
+                    2. Verify the record count for each stream is greater in Sync A than Sync B.
+                    3. Verify all records in Sync A and Sync B have replication key values which are
+                       greater than or equal to the corresponding start date for that sync.
+                    """
+                    # Criteria 1
+                    self.assertGreaterEqual(first_sync_count, second_sync_count)
+
+                    # Criteria 2
+                    self.assertIn(stream_name, first_sync_state['bookmarks'])
+                    self.assertIn(stream_name, second_sync_state['bookmarks'])
+
+                    # Criteria 3
+                    self.verify_replication_key_values(stream_name)

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -72,27 +72,39 @@ class StartDateTest(MambuBaseTest):
         sync
         """
 
-        conn_id = self.create_connection()
-        catalogs = menagerie.get_catalogs(conn_id)
+        # conn_id = self.create_connection()
+        # catalogs = menagerie.get_catalogs(conn_id)
 
-        self.select_all_streams_and_fields(conn_id, catalogs)
-        self.verify_stream_and_field_selection(conn_id)
+        # self.select_all_streams_and_fields(conn_id, catalogs)
+        # self.verify_stream_and_field_selection(conn_id)
 
-        # Run a sync job using orchestrator
-        first_sync_record_count_by_stream = self.run_and_verify_sync(conn_id)
-        first_sync_state = menagerie.get_state(conn_id)
-        first_sync_all_records_by_stream = runner.get_records_from_target_output()
+        # # Run a sync job using orchestrator
+        # first_sync_record_count_by_stream = self.run_and_verify_sync(conn_id)
+        # first_sync_state = menagerie.get_state(conn_id)
+        # first_sync_all_records_by_stream = runner.get_records_from_target_output()
 
-        conn_id = self.create_connection(original_properties=False)
-        catalogs = menagerie.get_catalogs(conn_id)
+        (_,
+         first_sync_record_count_by_stream,
+         first_sync_state,
+         first_sync_all_records_by_stream) = self.make_connection_and_run_sync()
 
-        self.select_all_streams_and_fields(conn_id, catalogs)
-        self.verify_stream_and_field_selection(conn_id)
+        (_,
+         second_sync_record_count_by_stream,
+         second_sync_state,
+         second_sync_all_records_by_stream) = self.make_connection_and_run_sync(
+             create_connection_kwargs={original_properties: False},
+         )
 
-        # Run a sync job using orchestrator
-        second_sync_record_count_by_stream = self.run_and_verify_sync(conn_id)
-        second_sync_state = menagerie.get_state(conn_id)
-        second_sync_all_records_by_stream = runner.get_records_from_target_output()
+        # conn_id = self.create_connection(original_properties=False)
+        # catalogs = menagerie.get_catalogs(conn_id)
+
+        # self.select_all_streams_and_fields(conn_id, catalogs)
+        # self.verify_stream_and_field_selection(conn_id)
+
+        # # Run a sync job using orchestrator
+        # second_sync_record_count_by_stream = self.run_and_verify_sync(conn_id)
+        # second_sync_state = menagerie.get_state(conn_id)
+        # second_sync_all_records_by_stream = runner.get_records_from_target_output()
 
         all_metadata = self.expected_metadata()
 

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -28,9 +28,6 @@ class StartDateTest(MambuBaseTest):
             original_properties=False
         )['start_date']
 
-    def expected_sync_streams(self):
-        return self.expected_streams() - self.untestable_streams()
-
     def untestable_streams(self):
         return set([
             "communications", # Need to set up Twilio or email server to send stuff

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -75,7 +75,6 @@ class StartDateTest(MambuBaseTest):
         conn_id = self.create_connection()
         catalogs = menagerie.get_catalogs(conn_id)
 
-        # Select all fields
         self.select_all_streams_and_fields(conn_id, catalogs)
         self.verify_stream_and_field_selection(conn_id)
 

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -1,11 +1,9 @@
 """
 Test that the tap respects the start date
 """
-
-from tap_tester import runner, menagerie, connections
-
+from singer.utils import strptime_to_utc
 from base import MambuBaseTest
-import singer
+
 
 class StartDateTest(MambuBaseTest):
     """
@@ -49,8 +47,8 @@ class StartDateTest(MambuBaseTest):
 
         for value in rep_values:
             self.assertGreaterEqual(
-                singer.utils.strptime_to_utc(value),
-                singer.utils.strptime_to_utc(start_date)
+                strptime_to_utc(value),
+                strptime_to_utc(start_date)
             )
 
     def verify_replication_key_values(self, stream_name):
@@ -92,7 +90,7 @@ class StartDateTest(MambuBaseTest):
          second_sync_record_count_by_stream,
          second_sync_state,
          second_sync_all_records_by_stream) = self.make_connection_and_run_sync(
-             create_connection_kwargs={original_properties: False},
+             create_connection_kwargs={"original_properties": False},
          )
 
         # conn_id = self.create_connection(original_properties=False)

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -76,14 +76,7 @@ class StartDateTest(MambuBaseTest):
         catalogs = menagerie.get_catalogs(conn_id)
 
         # Select all fields
-        for catalog_entry in catalogs:
-            if catalog_entry["tap_stream_id"] in self.expected_sync_streams():
-                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
-                connections.select_catalog_and_fields_via_metadata(
-                    conn_id,
-                    catalog_entry,
-                    schema,
-                )
+        self.select_all_streams_and_fields(conn_id, catalogs)
 
         # For expected sync streams, verify that
         # - all fields are selected

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -77,36 +77,7 @@ class StartDateTest(MambuBaseTest):
 
         # Select all fields
         self.select_all_streams_and_fields(conn_id, catalogs)
-
-        # For expected sync streams, verify that
-        # - all fields are selected
-        # - automatic fields are automatic
-        # - non-automatic fields are "inclusion": "available"
-        catalogs = menagerie.get_catalogs(conn_id)
-
-        for catalog_entry in catalogs:
-            tap_stream_id = catalog_entry['tap_stream_id']
-            if tap_stream_id in self.expected_sync_streams():
-                schema = menagerie.get_annotated_schema(conn_id, catalog_entry['stream_id'])
-                entry_metadata = schema.get('metadata', [])
-
-                for mdata in entry_metadata:
-                    is_selected = mdata.get('metadata').get('selected')
-                    if mdata.get('breadcrumb') == []:
-                        self.assertTrue(is_selected)
-                    else:
-                        inclusion = mdata.get('metadata', {}).get('inclusion')
-                        field_name = mdata.get('breadcrumb', ['properties', None])[1]
-
-                        automatic_fields = self.expected_automatic_fields()[tap_stream_id]
-
-                        self.assertIsNotNone(field_name)
-
-                        if field_name in automatic_fields:
-                            self.assertTrue(inclusion == 'automatic')
-                        else:
-                            self.assertTrue(is_selected)
-                            self.assertTrue(inclusion == 'available')
+        self.verify_stream_and_field_selection(conn_id)
 
         # Run a sync job using orchestrator
         first_sync_record_count_by_stream = self.run_and_verify_sync(conn_id)

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -4,7 +4,6 @@ Test that the tap respects the start date
 from singer.utils import strptime_to_utc
 from base import MambuBaseTest
 
-
 class StartDateTest(MambuBaseTest):
     """
     Test that the tap respects the start date
@@ -69,18 +68,6 @@ class StartDateTest(MambuBaseTest):
         future and running a sync results in less records than the first
         sync
         """
-
-        # conn_id = self.create_connection()
-        # catalogs = menagerie.get_catalogs(conn_id)
-
-        # self.select_all_streams_and_fields(conn_id, catalogs)
-        # self.verify_stream_and_field_selection(conn_id)
-
-        # # Run a sync job using orchestrator
-        # first_sync_record_count_by_stream = self.run_and_verify_sync(conn_id)
-        # first_sync_state = menagerie.get_state(conn_id)
-        # first_sync_all_records_by_stream = runner.get_records_from_target_output()
-
         (_,
          first_sync_record_count_by_stream,
          first_sync_state,
@@ -92,17 +79,6 @@ class StartDateTest(MambuBaseTest):
          second_sync_all_records_by_stream) = self.make_connection_and_run_sync(
              create_connection_kwargs={"original_properties": False},
          )
-
-        # conn_id = self.create_connection(original_properties=False)
-        # catalogs = menagerie.get_catalogs(conn_id)
-
-        # self.select_all_streams_and_fields(conn_id, catalogs)
-        # self.verify_stream_and_field_selection(conn_id)
-
-        # # Run a sync job using orchestrator
-        # second_sync_record_count_by_stream = self.run_and_verify_sync(conn_id)
-        # second_sync_state = menagerie.get_state(conn_id)
-        # second_sync_all_records_by_stream = runner.get_records_from_target_output()
 
         all_metadata = self.expected_metadata()
 

--- a/tests/test_sync_canary.py
+++ b/tests/test_sync_canary.py
@@ -1,0 +1,42 @@
+"""
+Test that with no fields selected for a stream automatic fields are still replicated
+"""
+
+from tap_tester import runner, menagerie
+
+from base import MambuBaseTest
+
+
+class SyncCanaryTest(MambuBaseTest):
+    """
+    Smoke test
+    """
+
+    @staticmethod
+    def name():
+        return "tap_tester_mambu_sync_canary_test"
+
+    def test_run(self):
+        """
+        Run tap in check mode, then select all streams and all fields within streams. Run a sync and
+        verify exit codes do not throw errors. This is meant to be a smoke test for the tap. If this
+        is failing do not expect any other tests to pass.
+        """
+        conn_id = self.create_connection()
+        catalogs = menagerie.get_catalogs(conn_id)
+
+        self.select_all_streams_and_fields(conn_id, catalogs)
+
+        # Verify all expected streams are selected
+        # Verify all fields for expected streams are selected
+        self.verify_field_selection(conn_id, self.expected_streams())
+
+        # Run a sync job using orchestrator
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
+
+        # Assert all expected streams synced at least one record
+        for stream in self.expected_streams():
+            with self.subTest(stream=stream):
+                self.assertGreater(record_count_by_stream.get(stream, 0),
+                                   0,
+                                   msg="{} did not sync any records".format(stream))

--- a/tests/test_sync_canary.py
+++ b/tests/test_sync_canary.py
@@ -1,11 +1,7 @@
 """
 Test that with no fields selected for a stream automatic fields are still replicated
 """
-
-from tap_tester import runner, menagerie
-
 from base import MambuBaseTest
-
 
 class SyncCanaryTest(MambuBaseTest):
     """
@@ -31,7 +27,7 @@ class SyncCanaryTest(MambuBaseTest):
         # # Run a sync job using orchestrator
         # record_count_by_stream = self.run_and_verify_sync(conn_id)
 
-        (conn_id,
+        (_,
          record_count_by_stream,
          _,
          _) = self.make_connection_and_run_sync()

--- a/tests/test_sync_canary.py
+++ b/tests/test_sync_canary.py
@@ -18,15 +18,6 @@ class SyncCanaryTest(MambuBaseTest):
         verify exit codes do not throw errors. This is meant to be a smoke test for the tap. If this
         is failing do not expect any other tests to pass.
         """
-        # conn_id = self.create_connection()
-        # catalogs = menagerie.get_catalogs(conn_id)
-
-        # self.select_all_streams_and_fields(conn_id, catalogs)
-        # self.verify_stream_and_field_selection(conn_id)
-
-        # # Run a sync job using orchestrator
-        # record_count_by_stream = self.run_and_verify_sync(conn_id)
-
         (_,
          record_count_by_stream,
          _,

--- a/tests/test_sync_canary.py
+++ b/tests/test_sync_canary.py
@@ -26,10 +26,7 @@ class SyncCanaryTest(MambuBaseTest):
         catalogs = menagerie.get_catalogs(conn_id)
 
         self.select_all_streams_and_fields(conn_id, catalogs)
-
-        # Verify all expected streams are selected
-        # Verify all fields for expected streams are selected
-        self.verify_field_selection(conn_id, self.expected_streams())
+        self.verify_stream_and_field_selection(conn_id)
 
         # Run a sync job using orchestrator
         record_count_by_stream = self.run_and_verify_sync(conn_id)

--- a/tests/test_sync_canary.py
+++ b/tests/test_sync_canary.py
@@ -1,6 +1,7 @@
 """
 Test that with no fields selected for a stream automatic fields are still replicated
 """
+from tap_tester import connections
 from base import MambuBaseTest
 
 class SyncCanaryTest(MambuBaseTest):
@@ -18,10 +19,13 @@ class SyncCanaryTest(MambuBaseTest):
         verify exit codes do not throw errors. This is meant to be a smoke test for the tap. If this
         is failing do not expect any other tests to pass.
         """
-        (_,
-         record_count_by_stream,
-         _,
-         _) = self.make_connection_and_run_sync()
+        conn_id = connections.ensure_connection(self)
+        self.run_and_verify_check_mode(conn_id)
+
+        self.select_and_verify_fields(conn_id)
+
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
+
 
         # Assert all expected streams synced at least one record
         for stream in self.expected_streams():

--- a/tests/test_sync_canary.py
+++ b/tests/test_sync_canary.py
@@ -22,14 +22,19 @@ class SyncCanaryTest(MambuBaseTest):
         verify exit codes do not throw errors. This is meant to be a smoke test for the tap. If this
         is failing do not expect any other tests to pass.
         """
-        conn_id = self.create_connection()
-        catalogs = menagerie.get_catalogs(conn_id)
+        # conn_id = self.create_connection()
+        # catalogs = menagerie.get_catalogs(conn_id)
 
-        self.select_all_streams_and_fields(conn_id, catalogs)
-        self.verify_stream_and_field_selection(conn_id)
+        # self.select_all_streams_and_fields(conn_id, catalogs)
+        # self.verify_stream_and_field_selection(conn_id)
 
-        # Run a sync job using orchestrator
-        record_count_by_stream = self.run_and_verify_sync(conn_id)
+        # # Run a sync job using orchestrator
+        # record_count_by_stream = self.run_and_verify_sync(conn_id)
+
+        (conn_id,
+         record_count_by_stream,
+         _,
+         _) = self.make_connection_and_run_sync()
 
         # Assert all expected streams synced at least one record
         for stream in self.expected_streams():


### PR DESCRIPTION
# Description of change
This PR closes #26 as we needed that to get the tests passing.

Adds the following tests:
* `test_sync_canary`
* `test_automatic_fields`
* `test_discovery`  
* `test_bookmarks`
* `test_pagination`
* `test_start_date`

# Manual QA steps
 - Ran the full test suite locally before opening this PR
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
