### PR TITLE
bump to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.0
+  * Added integration tests
+  * Added api key auth
+  * Fixed issue where some streams did not automatically select replication keys
+
 ## 1.2.0
   * Added endpoints: activities, index rate sources, installments. Client, Groups, GL Journal Entries endpoints changed.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='1.2.0',
+      version='1.3.0',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
bump to 1.3.0, see #27 and #28

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
