### PR TITLE
Expand "multipleOf" schema constraint causing validation errors.

### DIFF
--- a/tap_mambu/schemas/branches.json
+++ b/tap_mambu/schemas/branches.json
@@ -23,8 +23,8 @@
                 "type": ["null", "string"]
               },
               "latitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "postcode": {
                 "type": ["null", "string"]
@@ -45,8 +45,8 @@
                 "type": ["null", "string"]
               },
               "longitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               }
             }
           }

--- a/tap_mambu/schemas/centres.json
+++ b/tap_mambu/schemas/centres.json
@@ -20,8 +20,8 @@
                 "type": ["null", "string"]
               },
               "latitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "postcode": {
                 "type": ["null", "string"]
@@ -42,8 +42,8 @@
                 "type": ["null", "string"]
               },
               "longitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               }
             }
           }

--- a/tap_mambu/schemas/clients.json
+++ b/tap_mambu/schemas/clients.json
@@ -29,8 +29,8 @@
                 "type": ["null", "string"]
               },
               "latitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "postcode": {
                 "type": ["null", "string"]
@@ -51,8 +51,8 @@
                 "type": ["null", "string"]
               },
               "longitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               }
             }
           }

--- a/tap_mambu/schemas/credit_arrangements.json
+++ b/tap_mambu/schemas/credit_arrangements.json
@@ -3,12 +3,12 @@
   "additionalProperties": false,
   "properties": {
     "available_credit_amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
+      "type": ["null", "string"],
+      "format": "singer.decimal"
     },
     "amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
+      "type": ["null", "string"],
+      "format": "singer.decimal"
     },
     "notes": {
       "type": ["null", "string"]
@@ -21,8 +21,8 @@
       "type": ["null", "string"]
     },
     "consumed_credit_amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
+      "type": ["null", "string"],
+      "format": "singer.decimal"
     },
     "creation_date": {
       "type": ["null", "string"],

--- a/tap_mambu/schemas/deposit_accounts.json
+++ b/tap_mambu/schemas/deposit_accounts.json
@@ -35,8 +35,8 @@
           "additionalProperties": false,
           "properties": {
             "interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
+              "type": ["null", "string"],
+              "format": "singer.decimal",
               "minimum": -1000000000000000,
               "maximum": 1000000000000000
             },
@@ -49,12 +49,12 @@
                     "additionalProperties": false,
                     "properties": {
                       "ending_balance": {
-                        "type": ["null", "number"],
-                        "multipleOf": 1e-10
+                        "type": ["null", "string"],
+                        "format": "singer.decimal"
                       },
                       "interest_rate": {
-                        "type": ["null", "number"],
-                        "multipleOf": 1e-20,
+                        "type": ["null", "string"],
+                        "format": "singer.decimal",
                         "minimum": -1000000000000000,
                         "maximum": 1000000000000000
                       },
@@ -124,40 +124,40 @@
       "additionalProperties": false,
       "properties": {
         "overdraft_interest_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "total_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "locked_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "technical_overdraft_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "overdraft_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "hold_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "technical_overdraft_interest_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "fees_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "available_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         }
       }
     },
@@ -182,8 +182,8 @@
           "type": ["null", "boolean"]
         },
         "overdraft_limit": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "overdraft_expiry_date": {
           "type": ["null", "string"],
@@ -210,14 +210,14 @@
           "additionalProperties": false,
           "properties": {
             "interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
+              "type": ["null", "string"],
+              "format": "singer.decimal",
               "minimum": -1000000000000000,
               "maximum": 1000000000000000
             },
             "interest_spread": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
+              "type": ["null", "string"],
+              "format": "singer.decimal",
               "minimum": -1000000000000000,
               "maximum": 1000000000000000
             },
@@ -239,12 +239,12 @@
                     "additionalProperties": false,
                     "properties": {
                       "ending_balance": {
-                        "type": ["null", "number"],
-                        "multipleOf": 1e-10
+                        "type": ["null", "string"],
+                        "format": "singer.decimal"
                       },
                       "interest_rate": {
-                        "type": ["null", "number"],
-                        "multipleOf": 1e-20,
+                        "type": ["null", "string"],
+                        "format": "singer.decimal",
                         "minimum": -1000000000000000,
                         "maximum": 1000000000000000
                       },
@@ -313,16 +313,16 @@
       "additionalProperties": false,
       "properties": {
         "overdraft_interest_accrued": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "interest_accrued": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "technical_overdraft_interest_accrued": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         }
       }
     },
@@ -344,16 +344,16 @@
       "additionalProperties": false,
       "properties": {
         "recommended_deposit_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "target_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "max_withdrawal_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         }
       }
     },

--- a/tap_mambu/schemas/deposit_products.json
+++ b/tap_mambu/schemas/deposit_products.json
@@ -62,12 +62,12 @@
                 "additionalProperties": false,
                 "properties": {
                   "ending_balance": {
-                    "type": ["null", "number"],
-                    "multipleOf": 1e-10
+                    "type": ["null", "string"],
+                    "format": "singer.decimal"
                   },
                   "interest_rate": {
-                    "type": ["null", "number"],
-                    "multipleOf": 1e-20,
+                    "type": ["null", "string"],
+                    "format": "singer.decimal",
                     "minimum": -1000000000000000,
                     "maximum": 1000000000000000
                   },
@@ -133,12 +133,12 @@
                 "additionalProperties": false,
                 "properties": {
                   "ending_balance": {
-                    "type": ["null", "number"],
-                    "multipleOf": 1e-10
+                    "type": ["null", "string"],
+                    "format": "singer.decimal"
                   },
                   "interest_rate": {
-                    "type": ["null", "number"],
-                    "multipleOf": 1e-20,
+                    "type": ["null", "string"],
+                    "format": "singer.decimal",
                     "minimum": -1000000000000000,
                     "maximum": 1000000000000000
                   },

--- a/tap_mambu/schemas/deposit_transactions.json
+++ b/tap_mambu/schemas/deposit_transactions.json
@@ -29,15 +29,15 @@
                 "type": ["null", "string"]
               },
               "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "trigger": {
                 "type": ["null", "string"]
               },
               "tax_amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "predefined_fee_key": {
                 "type": ["null", "string"]
@@ -58,40 +58,40 @@
       "additionalProperties": false,
       "properties": {
         "fees_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "overdraft_interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "overdraft_fees_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "fraction_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "technical_overdraft_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "overdraft_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "technical_overdraft_interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "funds_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         }
       }
     },
@@ -103,8 +103,8 @@
           "type": ["null", "string"]
         },
         "amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "advice": {
           "type": ["null", "boolean"]
@@ -156,8 +156,8 @@
       "additionalProperties": false,
       "properties": {
         "tax_rate": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20,
+          "type": ["null", "string"],
+          "format": "singer.decimal",
           "minimum": -1000000000000000,
           "maximum": 1000000000000000
         }
@@ -184,8 +184,8 @@
           "additionalProperties": false,
           "properties": {
             "interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
+              "type": ["null", "string"],
+              "format": "singer.decimal",
               "minimum": -1000000000000000,
               "maximum": 1000000000000000
             }
@@ -196,8 +196,8 @@
           "additionalProperties": false,
           "properties": {
             "overdraft_limit": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-10
+              "type": ["null", "string"],
+              "format": "singer.decimal"
             }
           }
         },
@@ -206,14 +206,14 @@
           "additionalProperties": false,
           "properties": {
             "interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
+              "type": ["null", "string"],
+              "format": "singer.decimal",
               "minimum": -1000000000000000,
               "maximum": 1000000000000000
             },
             "index_interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
+              "type": ["null", "string"],
+              "format": "singer.decimal",
               "minimum": -1000000000000000,
               "maximum": 1000000000000000
             }
@@ -243,8 +243,8 @@
       "type": ["null", "string"]
     },
     "amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
+      "type": ["null", "string"],
+      "format": "singer.decimal"
     },
     "centre_key": {
       "type": ["null", "string"]
@@ -274,8 +274,8 @@
       "additionalProperties": false,
       "properties": {
         "total_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         }
       }
     },

--- a/tap_mambu/schemas/gl_accounts.json
+++ b/tap_mambu/schemas/gl_accounts.json
@@ -66,8 +66,8 @@
         }
       },
       "balance": {
-        "type": ["null", "number"],
-        "multipleOf": 1e-10
+        "type": ["null", "string"],
+        "format": "singer.decimal"
       }
     }
   }

--- a/tap_mambu/schemas/gl_journal_entries.json
+++ b/tap_mambu/schemas/gl_journal_entries.json
@@ -26,8 +26,8 @@
         "type": ["null", "string"]
       },
       "amount": {
-        "type": ["null", "number"],
-        "multipleOf": 1e-10
+        "type": ["null", "string"],
+        "format": "singer.decimal"
       },
       "type": {
         "type": ["null", "string"]
@@ -107,8 +107,8 @@
             }
           },
           "balance": {
-            "type": ["null", "number"],
-            "multipleOf": 1e-10
+            "type": ["null", "string"],
+            "format": "singer.decimal"
           }
         }
       }

--- a/tap_mambu/schemas/groups.json
+++ b/tap_mambu/schemas/groups.json
@@ -70,8 +70,8 @@
                 "type": ["null", "string"]
               },
               "latitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "postcode": {
                 "type": ["null", "string"]
@@ -92,8 +92,8 @@
                 "type": ["null", "string"]
               },
               "longitude": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               }
             }
           }

--- a/tap_mambu/schemas/loan_accounts.json
+++ b/tap_mambu/schemas/loan_accounts.json
@@ -390,11 +390,11 @@
             "properties": {
               "amount": {
                 "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "multipleOf": 1e-20
               },
               "interest_commission": {
                 "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "multipleOf": 1e-20
               },
               "deposit_account_key": {
                 "type": ["null", "string"]
@@ -416,7 +416,7 @@
               },
               "share_percentage": {
                 "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "multipleOf": 1e-20
               }
             }
           }

--- a/tap_mambu/schemas/loan_accounts.json
+++ b/tap_mambu/schemas/loan_accounts.json
@@ -77,8 +77,8 @@
                     "type": ["null", "string"]
                   },
                   "amount": {
-                    "type": ["null", "number"],
-                    "multipleOf": 1e-10
+                    "type": ["null", "string"],
+                    "format": "singer.decimal"
                   }
                 }
               }
@@ -118,12 +118,12 @@
           "type": ["null", "string"]
         },
         "interest_spread": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "interest_rate": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20,
+          "type": ["null", "string"],
+          "format": "singer.decimal",
           "minimum": -1000000000000000,
           "maximum": 1000000000000000
         },
@@ -162,8 +162,8 @@
             "additionalProperties": false,
             "properties": {
               "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "deposit_account_key": {
                 "type": ["null", "string"]
@@ -215,12 +215,12 @@
       ]
     },
     "accrued_interest": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
+      "type": ["null", "string"],
+      "format": "singer.decimal"
     },
     "accrued_penalty": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
+      "type": ["null", "string"],
+      "format": "singer.decimal"
     },
     "creation_date": {
       "type": ["null", "string"],
@@ -241,8 +241,8 @@
                 "type": ["null", "string"]
               },
               "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "disbursement_details": {
                 "type": ["null", "object"],
@@ -273,8 +273,8 @@
       "format": "date-time"
     },
     "tax_rate": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-20,
+      "type": ["null", "string"],
+      "format": "singer.decimal",
       "minimum": -1000000000000000,
       "maximum": 1000000000000000
     },
@@ -283,8 +283,8 @@
       "format": "date-time"
     },
     "interest_from_arrears_accrued": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
+      "type": ["null", "string"],
+      "format": "singer.decimal"
     },
     "schedule_settings": {
       "type": ["null", "object"],
@@ -294,8 +294,8 @@
           "type": ["null", "integer"]
         },
         "periodic_payment": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "repayment_schedule_method": {
           "type": ["null", "string"]
@@ -315,8 +315,8 @@
                     "type": ["null", "string"]
                   },
                   "amount": {
-                    "type": ["null", "number"],
-                    "multipleOf": 1e-10
+                    "type": ["null", "string"],
+                    "format": "singer.decimal"
                   }
                 }
               }
@@ -389,12 +389,12 @@
             "additionalProperties": false,
             "properties": {
               "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-20
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "interest_commission": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-20
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "deposit_account_key": {
                 "type": ["null", "string"]
@@ -415,8 +415,8 @@
                 "type": ["null", "string"]
               },
               "share_percentage": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-20
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               }
             }
           }
@@ -450,68 +450,68 @@
       "additionalProperties": false,
       "properties": {
         "interest_from_arrears_paid": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "principal_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "interest_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "principal_paid": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "penalty_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "fees_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "penalty_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "redraw_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "interest_from_arrears_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "principal_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "interest_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "penalty_paid": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "fees_paid": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "interest_from_arrears_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "fees_due": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "interest_paid": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         }
       }
     },
@@ -519,8 +519,8 @@
       "type": ["null", "string"]
     },
     "interest_commission": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
+      "type": ["null", "string"],
+      "format": "singer.decimal"
     },
     "encoded_key": {
       "type": ["null", "string"]
@@ -537,8 +537,8 @@
           "type": ["null", "string"]
         },
         "penalty_rate": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20,
+          "type": ["null", "string"],
+          "format": "singer.decimal",
           "minimum": -1000000000000000,
           "maximum": 1000000000000000
         }
@@ -562,19 +562,19 @@
           "type": ["null", "string"]
         },
         "amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "principal_floor_value": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "principal_payment_method": {
           "type": ["null", "string"]
         },
         "percentage": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20,
+          "type": ["null", "string"],
+          "format": "singer.decimal",
           "minimum": -1000000000000000,
           "maximum": 1000000000000000
         },
@@ -585,12 +585,12 @@
           "type": ["null", "string"]
         },
         "total_due_amount_floor": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "principal_ceiling_value": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         }
       }
     },
@@ -599,8 +599,8 @@
       "format": "date-time"
     },
     "loan_amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
+      "type": ["null", "string"],
+      "format": "singer.decimal"
     },
     "closed_date": {
       "type": ["null", "string"],
@@ -621,8 +621,8 @@
             "additionalProperties": false,
             "properties": {
               "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "deposit_account_key": {
                 "type": ["null", "string"]

--- a/tap_mambu/schemas/loan_repayments.json
+++ b/tap_mambu/schemas/loan_repayments.json
@@ -24,58 +24,58 @@
       "principal_due": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "principal_paid": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "interest_due": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "interest_paid": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "fees_due": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "fees_paid": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "penalty_due": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "penalty_paid": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "state": {
         "type": [
@@ -86,44 +86,44 @@
       "tax_interest_due": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "tax_interest_paid": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "tax_fees_due": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "tax_fees_paid": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "tax_penalty_due": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       },
       "tax_penalty_paid": {
         "type": [
           "null",
-          "number"
+          "string"
         ],
-        "multipleOf": 1e-10
+        "format": "singer.decimal"
       }
     }
   }

--- a/tap_mambu/schemas/loan_transactions.json
+++ b/tap_mambu/schemas/loan_transactions.json
@@ -29,15 +29,15 @@
                 "type": ["null", "string"]
               },
               "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "trigger": {
                 "type": ["null", "string"]
               },
               "tax_amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "predefined_fee_key": {
                 "type": ["null", "string"]
@@ -58,40 +58,40 @@
       "additionalProperties": false,
       "properties": {
         "fees_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "overdraft_interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "overdraft_fees_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "fraction_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "technical_overdraft_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "overdraft_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "technical_overdraft_interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "funds_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         }
       }
     },
@@ -100,30 +100,30 @@
       "additionalProperties": false,
       "properties": {
         "tax_interest_from_arrears_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "tax_on_fees_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "tax_rate": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20,
+          "type": ["null", "string"],
+          "format": "singer.decimal",
           "minimum": -1000000000000000,
           "maximum": 1000000000000000
         },
         "tax_on_interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "tax_on_penalty_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "deferred_tax_on_interest_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         }
       }
     },
@@ -148,26 +148,26 @@
           "additionalProperties": false,
           "properties": {
             "interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
+              "type": ["null", "string"],
+              "format": "singer.decimal",
               "minimum": -1000000000000000,
               "maximum": 1000000000000000
             },
             "index_interest_rate": {
-              "type": ["null", "number"],
-              "multipleOf": 1e-20,
+              "type": ["null", "string"],
+              "format": "singer.decimal",
               "minimum": -1000000000000000,
               "maximum": 1000000000000000
             }
           }
         },
         "principal_payment_amount": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "principal_payment_percentage": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-20,
+          "type": ["null", "string"],
+          "format": "singer.decimal",
           "minimum": -1000000000000000,
           "maximum": 1000000000000000
         }
@@ -197,12 +197,12 @@
             "additionalProperties": false,
             "properties": {
               "tax_on_amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "amount": {
-                "type": ["null", "number"],
-                "multipleOf": 1e-10
+                "type": ["null", "string"],
+                "format": "singer.decimal"
               },
               "custom_payment_amount_type": {
                 "type": ["null", "string"]
@@ -228,8 +228,8 @@
       "type": ["null", "string"]
     },
     "amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
+      "type": ["null", "string"],
+      "format": "singer.decimal"
     },
     "centre_key": {
       "type": ["null", "string"]
@@ -252,8 +252,8 @@
       "type": ["null", "string"]
     },
     "original_amount": {
-      "type": ["null", "number"],
-      "multipleOf": 1e-10
+      "type": ["null", "string"],
+      "format": "singer.decimal"
     },
 
     "linked_loan_transaction_key": {
@@ -264,28 +264,28 @@
       "additionalProperties": false,
       "properties": {
         "redraw_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "principal_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "total_balance": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "expected_principal_redraw": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "advance_position": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         },
         "arrears_position": {
-          "type": ["null", "number"],
-          "multipleOf": 1e-10
+          "type": ["null", "string"],
+          "format": "singer.decimal"
         }
       }
     },

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -105,7 +105,7 @@ def process_records(catalog, #pylint: disable=too-many-branches
                         last_dttm = transform_datetime(last_datetime)
                         bookmark_dttm = transform_datetime(transformed_record[bookmark_field])
                         # Keep only records whose bookmark is after the last_datetime
-                        if bookmark_dttm > last_dttm:
+                        if bookmark_dttm >= last_dttm:
                             write_record(stream_name, transformed_record, time_extracted=time_extracted)
                             counter.increment()
                 else:

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -244,48 +244,52 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
         children = endpoint_config.get('children')
         if children:
             for child_stream_name, child_endpoint_config in children.items():
-                # For each parent record
-                for record in transformed_data:
-                    i = 0
-                    # Set parent_id
-                    for id_field in id_fields:
-                        if i == 0:
-                            parent_id_field = id_field
-                        if id_field == 'id':
-                            parent_id_field = id_field
-                        i = i + 1
-                    parent_id = record.get(parent_id_field)
+                should_stream, last_stream_child = should_sync_stream(get_selected_streams(catalog),
+                                                            None,
+                                                            child_stream_name)
+                if should_stream:
+                    # For each parent record
+                    for record in transformed_data:
+                        i = 0
+                        # Set parent_id
+                        for id_field in id_fields:
+                            if i == 0:
+                                parent_id_field = id_field
+                            if id_field == 'id':
+                                parent_id_field = id_field
+                            i = i + 1
+                        parent_id = record.get(parent_id_field)
 
-                    # sync_endpoint for child
-                    LOGGER.info('Syncing: {}, parent_stream: {}, parent_id: {}'.format(
-                        child_stream_name,
-                        stream_name,
-                        parent_id))
-                    child_path = child_endpoint_config.get('path').format(str(parent_id))
-                    child_total_records = sync_endpoint(
-                        client=client,
-                        catalog=catalog,
-                        state=state,
-                        start_date=start_date,
-                        stream_name=child_stream_name,
-                        path=child_path,
-                        endpoint_config=child_endpoint_config,
-                        api_version=child_endpoint_config.get('api_version', 'v2'),
-                        api_method=child_endpoint_config.get('api_method', 'GET'),
-                        static_params=child_endpoint_config.get('params', {}),
-                        sub_type=sub_type,
-                        bookmark_query_field=child_endpoint_config.get('bookmark_query_field'),
-                        bookmark_field=child_endpoint_config.get('bookmark_field'),
-                        bookmark_type=child_endpoint_config.get('bookmark_type'),
-                        data_key=child_endpoint_config.get('data_key', None),
-                        body=child_endpoint_config.get('body', None),
-                        id_fields=child_endpoint_config.get('id_fields'),
-                        parent=child_endpoint_config.get('parent'),
-                        parent_id=parent_id)
-                    LOGGER.info('Synced: {}, parent_id: {}, total_records: {}'.format(
-                        child_stream_name,
-                        parent_id,
-                        child_total_records))
+                        # sync_endpoint for child
+                        LOGGER.info('Syncing: {}, parent_stream: {}, parent_id: {}'.format(
+                            child_stream_name,
+                            stream_name,
+                            parent_id))
+                        child_path = child_endpoint_config.get('path').format(str(parent_id))
+                        child_total_records = sync_endpoint(
+                            client=client,
+                            catalog=catalog,
+                            state=state,
+                            start_date=start_date,
+                            stream_name=child_stream_name,
+                            path=child_path,
+                            endpoint_config=child_endpoint_config,
+                            api_version=child_endpoint_config.get('api_version', 'v2'),
+                            api_method=child_endpoint_config.get('api_method', 'GET'),
+                            static_params=child_endpoint_config.get('params', {}),
+                            sub_type=sub_type,
+                            bookmark_query_field=child_endpoint_config.get('bookmark_query_field'),
+                            bookmark_field=child_endpoint_config.get('bookmark_field'),
+                            bookmark_type=child_endpoint_config.get('bookmark_type'),
+                            data_key=child_endpoint_config.get('data_key', None),
+                            body=child_endpoint_config.get('body', None),
+                            id_fields=child_endpoint_config.get('id_fields'),
+                            parent=child_endpoint_config.get('parent'),
+                            parent_id=parent_id)
+                        LOGGER.info('Synced: {}, parent_id: {}, total_records: {}'.format(
+                            child_stream_name,
+                            parent_id,
+                            child_total_records))
 
 
         # to_rec: to record; ending record for the batch
@@ -334,6 +338,20 @@ def update_currently_syncing(state, stream_name):
     else:
         singer.set_currently_syncing(state, stream_name)
     singer.write_state(state)
+
+
+# Review last_stream (last currently syncing stream), if any,
+#  and continue where it left off in the selected streams.
+# Or begin from the beginning, if no last_stream, and sync
+#  all selected steams.
+# Returns should_sync_stream (true/false) and last_stream.
+def should_sync_stream(selected_streams, last_stream, stream_name):
+    if last_stream == stream_name or last_stream is None:
+        if last_stream is not None:
+            last_stream = None
+        if stream_name in selected_streams:
+            return True, last_stream
+    return False, last_stream
 
 
 def sync(client, config, catalog, state):
@@ -727,90 +745,92 @@ def sync(client, config, catalog, state):
 
     # For each endpoint (above), determine if the stream should be streamed
     #   (based on the catalog and last_stream), then sync those streams.
-    for stream_name in selected_streams:
+    for stream_name, endpoint_config in endpoints.items():
+        should_stream, last_stream = should_sync_stream(selected_streams,
+                                                        last_stream,
+                                                        stream_name)
 
-        endpoint_config = endpoints.get(stream_name)
-        if endpoint_config is None:
-            continue
+        if should_stream:
+            # loop through each sub type
+            sub_types = endpoint_config.get('sub_types', ['self'])
+            for sub_type in sub_types:
+                LOGGER.info('START Syncing: {}, Type: {}'.format(stream_name, sub_type))
 
-        # loop through each sub type
-        sub_types = endpoint_config.get('sub_types', ['self'])
-        for sub_type in sub_types:
-            LOGGER.info('START Syncing: {}, Type: {}'.format(stream_name, sub_type))
+                # Now date
+                if stream_name == 'gl_journal_entries':
+                    now_date_str = strftime(utils.now())[:10]
+                    gl_journal_entries_from_dttm_str = get_bookmark(
+                        state, 'gl_journal_entries', sub_type, start_date)
+                    gl_journal_entries_from_dt_str = transform_datetime(
+                        gl_journal_entries_from_dttm_str)[:10]
+                    gl_journal_entries_from_param = endpoint_config.get(
+                        'body', {}).get('filterConstraints', {})[0].get('value')
+                    if gl_journal_entries_from_param:
+                        endpoint_config['body']['filterConstraints'][0]['value'] = gl_journal_entries_from_dt_str
+                    gl_journal_entries_to_param = endpoint_config.get(
+                        'body', {}).get('filterConstraints', {})[0].get('secondValue')
+                    if gl_journal_entries_to_param:
+                        endpoint_config['body']['filterConstraints'][0]['secondValue'] = now_date_str
 
-            # Now date
-            if stream_name == 'gl_journal_entries':
-                now_date_str = strftime(utils.now())[:10]
-                gl_journal_entries_from_dttm_str = get_bookmark(
-                    state, 'gl_journal_entries', sub_type, start_date)
-                gl_journal_entries_from_dt_str = transform_datetime(
-                    gl_journal_entries_from_dttm_str)[:10]
-                gl_journal_entries_from_param = endpoint_config.get(
-                    'body', {}).get('filterConstraints', {})[0].get('value')
-                if gl_journal_entries_from_param:
-                    endpoint_config['body']['filterConstraints'][0]['value'] = gl_journal_entries_from_dt_str
-                gl_journal_entries_to_param = endpoint_config.get(
-                    'body', {}).get('filterConstraints', {})[0].get('secondValue')
-                if gl_journal_entries_to_param:
-                    endpoint_config['body']['filterConstraints'][0]['secondValue'] = now_date_str
+                if stream_name == 'activities':
+                    now_date_str = strftime(utils.now())[:10]
+                    activities_from_dttm_str = get_bookmark(
+                        state, 'activities', sub_type, start_date)
+                    activities_from_dt_str = transform_datetime(
+                        activities_from_dttm_str)[:10]
+                    activities_from_param = endpoint_config.get(
+                        'params', {}).get('from')
+                    if activities_from_param:
+                        endpoint_config['params']['from'] = activities_from_dt_str
+                    activities_to_param = endpoint_config.get(
+                        'params', {}).get('to')
+                    if activities_to_param:
+                        endpoint_config['params']['to'] = now_date_str
 
-            if stream_name == 'activities':
-                now_date_str = strftime(utils.now())[:10]
-                activities_from_dttm_str = get_bookmark(
-                    state, 'activities', sub_type, start_date)
-                activities_from_dt_str = transform_datetime(
-                    activities_from_dttm_str)[:10]
-                activities_from_param = endpoint_config.get(
-                    'params', {}).get('from')
-                if activities_from_param:
-                    endpoint_config['params']['from'] = activities_from_dt_str
-                activities_to_param = endpoint_config.get(
-                    'params', {}).get('to')
-                if activities_to_param:
-                    endpoint_config['params']['to'] = now_date_str
+                if stream_name == 'installments':
+                    now_date_str = strftime(utils.now())[:10]
+                    installments_from_dttm_str = get_bookmark(
+                        state, 'installments', sub_type, start_date)
+                    installments_from_dt_str = transform_datetime(
+                        installments_from_dttm_str)[:10]
+                    installments_from_param = endpoint_config.get(
+                        'params', {}).get('dueFrom')
+                    if installments_from_param:
+                        endpoint_config['params']['dueFrom'] = installments_from_dt_str
+                    installments_to_param = endpoint_config.get(
+                        'params', {}).get('dueTo')
+                    if installments_to_param:
+                        endpoint_config['params']['dueTo'] = now_date_str
 
-            if stream_name == 'installments':
-                now_date_str = strftime(utils.now())[:10]
-                installments_from_dttm_str = get_bookmark(
-                    state, 'installments', sub_type, start_date)
-                installments_from_dt_str = transform_datetime(
-                    installments_from_dttm_str)[:10]
-                installments_from_param = endpoint_config.get(
-                    'params', {}).get('dueFrom')
-                if installments_from_param:
-                    endpoint_config['params']['dueFrom'] = installments_from_dt_str
-                installments_to_param = endpoint_config.get(
-                    'params', {}).get('dueTo')
-                if installments_to_param:
-                    endpoint_config['params']['dueTo'] = now_date_str
 
-            update_currently_syncing(state, stream_name)
-            path = endpoint_config.get('path')
-            sub_type_param = endpoint_config.get('params', {}).get('type')
-            if sub_type_param:
-                endpoint_config['params']['type'] = sub_type
+                update_currently_syncing(state, stream_name)
+                path = endpoint_config.get('path')
+                sub_type_param = endpoint_config.get('params', {}).get('type')
+                if sub_type_param:
+                    endpoint_config['params']['type'] = sub_type
 
-            total_records = sync_endpoint(
-                client=client,
-                catalog=catalog,
-                state=state,
-                start_date=start_date,
-                stream_name=stream_name,
-                path=path,
-                endpoint_config=endpoint_config,
-                api_version=endpoint_config.get('api_version', 'v2'),
-                api_method=endpoint_config.get('api_method', 'GET'),
-                static_params=endpoint_config.get('params', {}),
-                sub_type=sub_type,
-                bookmark_query_field=endpoint_config.get('bookmark_query_field'),
-                bookmark_field=endpoint_config.get('bookmark_field'),
-                bookmark_type=endpoint_config.get('bookmark_type'),
-                data_key=endpoint_config.get('data_key', None),
-                body=endpoint_config.get('body', None),
-                id_fields=endpoint_config.get('id_fields'))
 
-            update_currently_syncing(state, None)
-            LOGGER.info('Synced: {}, total_records: {}'.format(
-                            stream_name,
-                            total_records))
-            LOGGER.info('FINISHED Syncing: {}'.format(stream_name))
+                total_records = sync_endpoint(
+                    client=client,
+                    catalog=catalog,
+                    state=state,
+                    start_date=start_date,
+                    stream_name=stream_name,
+                    path=path,
+                    endpoint_config=endpoint_config,
+                    api_version=endpoint_config.get('api_version', 'v2'),
+                    api_method=endpoint_config.get('api_method', 'GET'),
+                    static_params=endpoint_config.get('params', {}),
+                    sub_type=sub_type,
+                    bookmark_query_field=endpoint_config.get('bookmark_query_field'),
+                    bookmark_field=endpoint_config.get('bookmark_field'),
+                    bookmark_type=endpoint_config.get('bookmark_type'),
+                    data_key=endpoint_config.get('data_key', None),
+                    body=endpoint_config.get('body', None),
+                    id_fields=endpoint_config.get('id_fields'))
+
+                update_currently_syncing(state, None)
+                LOGGER.info('Synced: {}, total_records: {}'.format(
+                                stream_name,
+                                total_records))
+                LOGGER.info('FINISHED Syncing: {}'.format(stream_name))

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -287,12 +287,6 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                         parent_id,
                         child_total_records))
 
-        # Update the state with the max_bookmark_value for the stream
-        if bookmark_field:
-            write_bookmark(state,
-                           stream_name,
-                           sub_type,
-                           max_bookmark_value)
 
         # to_rec: to record; ending record for the batch
         to_rec = offset + limit
@@ -307,6 +301,13 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
         offset = offset + limit
 
         # End: while record_count == limit
+
+    # Update the state with the max_bookmark_value for the stream
+    if bookmark_field:
+        write_bookmark(state,
+                        stream_name,
+                        sub_type,
+                        max_bookmark_value)
 
     # Return total_records across all batches
     return total_records

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -720,9 +720,17 @@ def sync(client, config, catalog, state):
     last_stream = singer.get_currently_syncing(state)
     LOGGER.info('last/currently syncing stream: {}'.format(last_stream))
 
+    # Start syncing from last/currently syncing stream
+    if last_stream in selected_streams:
+        selected_streams = selected_streams[selected_streams.index(last_stream):] + selected_streams[:selected_streams.index(last_stream)]
+
     # For each endpoint (above), determine if the stream should be streamed
     #   (based on the catalog and last_stream), then sync those streams.
-    for stream_name, endpoint_config in endpoints.items():
+    for stream_name in selected_streams:
+
+        endpoint_config = endpoints.get(stream_name)
+        if endpoint_config is None:
+            continue
 
         # loop through each sub type
         sub_types = endpoint_config.get('sub_types', ['self'])

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -58,6 +58,18 @@ def transform_datetime(this_dttm):
     return new_dttm
 
 
+def reorder_endpoint_configs(last_stream, endpoints):
+    endpoint_items = list(endpoints.items())
+
+    matching_index = 0
+    for idx, val in enumerate(endpoint_items):
+        if val[0] == last_stream:
+            matching_index = idx
+            break
+
+    return endpoint_items[matching_index:] + endpoint_items[:matching_index]
+
+
 def process_records(catalog, #pylint: disable=too-many-branches
                     stream_name,
                     records,
@@ -742,10 +754,11 @@ def sync(client, config, catalog, state):
     # Start syncing from last/currently syncing stream
     if last_stream in selected_streams:
         selected_streams = selected_streams[selected_streams.index(last_stream):] + selected_streams[:selected_streams.index(last_stream)]
+        endpoint_items = reorder_endpoint_configs(last_stream, endpoints)
 
     # For each endpoint (above), determine if the stream should be streamed
     #   (based on the catalog and last_stream), then sync those streams.
-    for stream_name, endpoint_config in endpoints.items():
+    for stream_name, endpoint_config in endpoint_items:
         should_stream, last_stream = should_sync_stream(selected_streams,
                                                         last_stream,
                                                         stream_name)

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -58,18 +58,6 @@ def transform_datetime(this_dttm):
     return new_dttm
 
 
-def reorder_endpoint_configs(last_stream, endpoints):
-    endpoint_items = list(endpoints.items())
-
-    matching_index = 0
-    for idx, val in enumerate(endpoint_items):
-        if val[0] == last_stream:
-            matching_index = idx
-            break
-
-    return endpoint_items[matching_index:] + endpoint_items[:matching_index]
-
-
 def process_records(catalog, #pylint: disable=too-many-branches
                     stream_name,
                     records,
@@ -754,11 +742,10 @@ def sync(client, config, catalog, state):
     # Start syncing from last/currently syncing stream
     if last_stream in selected_streams:
         selected_streams = selected_streams[selected_streams.index(last_stream):] + selected_streams[:selected_streams.index(last_stream)]
-        endpoint_items = reorder_endpoint_configs(last_stream, endpoints)
 
     # For each endpoint (above), determine if the stream should be streamed
     #   (based on the catalog and last_stream), then sync those streams.
-    for stream_name, endpoint_config in endpoint_items:
+    for stream_name, endpoint_config in endpoints.items():
         should_stream, last_stream = should_sync_stream(selected_streams,
                                                         last_stream,
                                                         stream_name)

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -745,7 +745,8 @@ def sync(client, config, catalog, state):
 
     # For each endpoint (above), determine if the stream should be streamed
     #   (based on the catalog and last_stream), then sync those streams.
-    for stream_name, endpoint_config in endpoints.items():
+    for stream_name in selected_streams:
+        endpoint_config = endpoints.get(stream_name)
         should_stream, last_stream = should_sync_stream(selected_streams,
                                                         last_stream,
                                                         stream_name)

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -741,21 +741,54 @@ def sync(client, config, catalog, state):
             # Now date
             if stream_name == 'gl_journal_entries':
                 now_date_str = strftime(utils.now())[:10]
-                gl_journal_entries_from_dttm_str = get_bookmark(state, 'gl_journal_entries', sub_type, start_date)
-                gl_journal_entries_from_dt_str = transform_datetime(gl_journal_entries_from_dttm_str)[:10]
+                gl_journal_entries_from_dttm_str = get_bookmark(
+                    state, 'gl_journal_entries', sub_type, start_date)
+                gl_journal_entries_from_dt_str = transform_datetime(
+                    gl_journal_entries_from_dttm_str)[:10]
+                gl_journal_entries_from_param = endpoint_config.get(
+                    'body', {}).get('filterConstraints', {})[0].get('value')
+                if gl_journal_entries_from_param:
+                    endpoint_config['body']['filterConstraints'][0]['value'] = gl_journal_entries_from_dt_str
+                gl_journal_entries_to_param = endpoint_config.get(
+                    'body', {}).get('filterConstraints', {})[0].get('secondValue')
+                if gl_journal_entries_to_param:
+                    endpoint_config['body']['filterConstraints'][0]['secondValue'] = now_date_str
+
+            if stream_name == 'activities':
+                now_date_str = strftime(utils.now())[:10]
+                activities_from_dttm_str = get_bookmark(
+                    state, 'activities', sub_type, start_date)
+                activities_from_dt_str = transform_datetime(
+                    activities_from_dttm_str)[:10]
+                activities_from_param = endpoint_config.get(
+                    'params', {}).get('from')
+                if activities_from_param:
+                    endpoint_config['params']['from'] = activities_from_dt_str
+                activities_to_param = endpoint_config.get(
+                    'params', {}).get('to')
+                if activities_to_param:
+                    endpoint_config['params']['to'] = now_date_str
+
+            if stream_name == 'installments':
+                now_date_str = strftime(utils.now())[:10]
+                installments_from_dttm_str = get_bookmark(
+                    state, 'installments', sub_type, start_date)
+                installments_from_dt_str = transform_datetime(
+                    installments_from_dttm_str)[:10]
+                installments_from_param = endpoint_config.get(
+                    'params', {}).get('dueFrom')
+                if installments_from_param:
+                    endpoint_config['params']['dueFrom'] = installments_from_dt_str
+                installments_to_param = endpoint_config.get(
+                    'params', {}).get('dueTo')
+                if installments_to_param:
+                    endpoint_config['params']['dueTo'] = now_date_str
 
             update_currently_syncing(state, stream_name)
             path = endpoint_config.get('path')
             sub_type_param = endpoint_config.get('params', {}).get('type')
             if sub_type_param:
                 endpoint_config['params']['type'] = sub_type
-
-            gl_journal_entries_from_param = endpoint_config.get('params', {}).get('from')
-            if gl_journal_entries_from_param:
-                endpoint_config['params']['from'] = gl_journal_entries_from_dt_str
-            gl_journal_entries_to_param = endpoint_config.get('params', {}).get('to')
-            if gl_journal_entries_to_param:
-                endpoint_config['params']['to'] = now_date_str
 
             total_records = sync_endpoint(
                 client=client,


### PR DESCRIPTION
# Description of change
The tap began receiving big decimal values that were bigger than the constraint defined in the schema for that stream's `funding_sources` field. The field accepts an array of objects and the properties of those objects have a `multipleOf` constraint of 1e-10. However, the tap failed due to a validation check error when receiving a value greater than that constraint. Fix is to expand that constraint from 1e-10 to 1e-20 to prevent validation failures for big decimal values.

# Manual QA steps
 - Simulate record which has a big decimal value like 33.333333333333336 in one of the property fields under the `funding_sources` field.
 
# Risks
 - Tested that it did not lead to breaking changes in Snowflake when changing from 1e-10 to 1e-20 but did not test to ensure it won't cause issues with other targets. Though since the field is an array of objects, I believe the target database should not have issues accepting bigger values.
 
# Rollback steps
 - revert this branch
