### PR TITLE
Fix re sync issue

### DIFF
--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -287,12 +287,6 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
                         parent_id,
                         child_total_records))
 
-        # Update the state with the max_bookmark_value for the stream
-        if bookmark_field:
-            write_bookmark(state,
-                           stream_name,
-                           sub_type,
-                           max_bookmark_value)
 
         # to_rec: to record; ending record for the batch
         to_rec = offset + limit
@@ -307,6 +301,13 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
         offset = offset + limit
 
         # End: while record_count == limit
+
+    # Update the state with the max_bookmark_value for the stream
+    if bookmark_field:
+        write_bookmark(state,
+                        stream_name,
+                        sub_type,
+                        max_bookmark_value)
 
     # Return total_records across all batches
     return total_records

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -720,9 +720,17 @@ def sync(client, config, catalog, state):
     last_stream = singer.get_currently_syncing(state)
     LOGGER.info('last/currently syncing stream: {}'.format(last_stream))
 
+    # Start syncing from last/currently syncing stream
+    if last_stream in selected_streams:
+        selected_streams = selected_streams[selected_streams.index(last_stream):] + selected_streams[:selected_streams.index(last_stream)]
+
     # For each endpoint (above), determine if the stream should be streamed
     #   (based on the catalog and last_stream), then sync those streams.
-    for stream_name, endpoint_config in endpoints.items():
+    for stream_name in selected_streams:
+
+        endpoint_config = endpoints.get(stream_name)
+        if endpoint_config is None:
+            continue
 
         # loop through each sub type
         sub_types = endpoint_config.get('sub_types', ['self'])


### PR DESCRIPTION
# Description of change
This fix removes the `should_sync_stream` function and associated logic which prevents the tap from re-syncing all the streams in the case where the previous run has exited with a failure. In the case where a state file is passed containing the `currently_syncing` key, the `should_sync_stream` would skip all the streams before reaching the one that matched `currently_syncing` and would only process that stream and any streams after it. Refactored to start syncing from the `currently_syncing` stream first and process all streams that also need to be synced. Additionally, modified logic that checks if a record should be written by comparing to the previous timestamp to only write the record if the timestamp is greater than the previous timestamp.

# Manual QA steps
 - Run the tap with a state file containing a `currently_syncing` stream. Ensure that all streams are still processed.
 
# Risks
 - N/A
 
# Rollback steps
 - revert this branch
