### PR TITLE
fix json validator to work with Python3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-mambu/lib/python3.5/site-packages/tap_mambu/schemas/*.json
+            stitch-validate-json tap_mambu/schemas/*.json
       - run:
           name: 'Integration Tests'
           command: |


### PR DESCRIPTION
# Description of change
Run the json validator against schemas in the checkout code rather than the virtual environment.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
