### PR TITLE
updated singer-python version to 5.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.3.3
+ * Updates singer-python version to 5.12.1  [#41](https://github.com/singer-io/tap-mambu/pull/41)
 
 ## 1.3.2
  * Changed `number` values to use `singer.decimal` in schemas  [#38](https://github.com/singer-io/tap-mambu/pull/38)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='1.3.2',
+      version='1.3.3',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
@@ -11,7 +11,7 @@ setup(name='tap-mambu',
       install_requires=[
           'backoff==1.8.0',
           'requests==2.23.0',
-          'singer-python==5.9.0'
+          'singer-python==5.12.1'
       ],
       extras_require={
           'dev': [


### PR DESCRIPTION
# Description of change
updated singer-python version to 5.12.1 to use singer.decimals

# Manual QA steps
 - 
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
