### PR TITLE
version bump to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 2.0.1
+  * Fix convert_custom_fields to handle lists as well as dicts [#47](https://github.com/singer-io/tap-mambu/pull/47)
+
 ## 2.0.0
   * Update custom field transformations and schema for streams.
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='2.0.0',
+      version='2.0.1',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
## 2.0.1  
* Fix convert_custom_fields to handle lists as well as dicts [#47](https://github.com/singer-io/tap-mambu/pull/47)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
