### PR TITLE
version bump pr v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.0
+  * Changes `deposit` and `locations` enpoint from GET to POST
+  * Adds `Audit trial` stream with new config property `apikey_audit`
+  * Adds `parent_account_key` field to `installments` stream [#49](https://github.com/singer-io/tap-mambu/pull/49)
+
 ## 2.0.1
   * Fix convert_custom_fields to handle lists as well as dicts [#47](https://github.com/singer-io/tap-mambu/pull/47)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='2.0.1',
+      version='2.1.0',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
changes from #49 
## 2.1.0
  * Changes `deposit` and `locations` enpoint from GET to POST
  * Adds `Audit trial` stream with new config property `apikey_audit`
  * Adds `parent_account_key` field to `installments` stream [#49](https://github.com/singer-io/tap-mambu/pull/49)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
