### PR TITLE
Query installments correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.1.1
+  * Query `installments` endpoint correctly using the `start_date` instead of bookmarked value [#54](https://github.com/singer-io/tap-mambu/pull/54)
+
 ## 2.1.0
   * Changes `deposit` and `locations` enpoint from GET to POST
   * Adds `Audit trial` stream with new config property `apikey_audit`

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='2.1.0',
+      version='2.1.1',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -231,7 +231,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
             transformed_data = transform_json(data, stream_name)
         elif data_key in data:
             transformed_data = transform_json(data, data_key)[data_key]
-      
+
         if stream_name == 'activities':
             transformed_data = transform_activities(transformed_data)
 
@@ -862,8 +862,7 @@ def sync(client, config, catalog, state):
 
                 if stream_name == 'installments':
                     now_date_str = strftime(utils.now())[:10]
-                    installments_from_dttm_str = get_bookmark(
-                        state, 'installments', sub_type, start_date)
+                    installments_from_dttm_str = start_date
                     installments_from_dt_str = transform_datetime(
                         installments_from_dttm_str)[:10]
                     installments_from_param = endpoint_config.get(


### PR DESCRIPTION
# Description of change
The installments endpoint queries via the `dueDate`. We were using the
bookmark value to generate the `dueFrom`, but we bookmark on the
`last_paid_date`. So on subsequent syncs we would not find any
installments with a due date prior to the latest `last_paid_date`.

# Manual QA steps
 - 
 
# Risks
 - The installments endpoint could return so much data that we are no longer able to process everything.
 
# Rollback steps
 - revert this branch
