### PR TITLE
Changed gl_journal_entries replication key

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ This tap:
 - Endpoint: https://instance.sandbox.mambu.com/api/gljournalentries/search
 - Primary keys: entry_id
 - Replication strategy: Incremental (query filtered based on date)
-  - Bookmark: booking_date (date-time)
+  - Bookmark: creation_date (date-time)
 - Transformations: Fields camelCase to snake_case, Abstract/generalize custom_field_sets
 
 [**activities (GET v1)**](https://support.mambu.com/docs/activities-api)

--- a/tap_mambu/schema.py
+++ b/tap_mambu/schema.py
@@ -95,7 +95,7 @@ STREAMS = {
     'gl_journal_entries': {
         'key_properties': ['entry_id'],
         'replication_method': 'INCREMENTAL',
-        'replication_keys': ['booking_date']
+        'replication_keys': ['creation_date']
     },
     'activities': {
         'key_properties': ['encoded_key'],

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -748,7 +748,7 @@ def sync(client, config, catalog, state):
                 ]
             },
             'id_fields': ['entry_id'],
-            'bookmark_field': 'booking_date',
+            'bookmark_field': 'creation_date',
             'bookmark_type': 'datetime'
         },
         'activities': {


### PR DESCRIPTION
# Description of change
Changed `replication_keys` and `bookmark_field` for _gl_journal_entries_ stream from `booking_date` to `creation_date`.
The problem that this change solves is that, currently, we are missing journal entries records when transactions are reversed.

A test that was performed (without code changes):
1. set `start_date` to current date
2. reversed a transaction with a booking date in the past
3. synced the _gl_journal_entries_ stream records.

The **expected** result: at least the reversed transaction records.
The **actual** result: didn't get the records for the reversed transaction.

After the change from `booking_date` to `creation_date`, the reversed transactions were synced.

Here are some json snippets (`"start_date": "2021-10-18T00:00:00.000000Z"`):
**Result before code changes**
```
{"type": "RECORD", "stream": "gl_journal_entries", "record": {"entry_id": "31986", "creation_date": "2021-10-17T21:25:32.000000Z", "entry_date": "2021-10-18T00:00:00.000000Z", "amount": "295.75", "booking_date": "2021-10-18T00:00:00.000000Z"}, "time_extracted": "2021-10-18T09:49:40.267352Z"}

{"type": "RECORD", "stream": "gl_journal_entries", "record": {"entry_id": "31987", "creation_date": "2021-10-17T21:25:32.000000Z", "entry_date": "2021-10-18T00:00:00.000000Z", "amount": "295.75", "booking_date": "2021-10-18T00:00:00.000000Z"}, "time_extracted": "2021-10-18T09:49:40.267352Z"}

{"type": "RECORD", "stream": "gl_journal_entries", "record": {"entry_id": "31990", "creation_date": "2021-10-17T21:26:03.000000Z", "entry_date": "2021-10-18T00:00:00.000000Z", "amount": "277.78", "booking_date": "2021-10-18T00:00:00.000000Z"}, "time_extracted": "2021-10-18T09:49:40.267352Z"}

{"type": "RECORD", "stream": "gl_journal_entries", "record": {"entry_id": "31991", "creation_date": "2021-10-17T21:26:03.000000Z", "entry_date": "2021-10-18T00:00:00.000000Z", "amount": "277.78", "booking_date": "2021-10-18T00:00:00.000000Z"}, "time_extracted": "2021-10-18T09:49:40.267352Z"}

```

**Result after code changes**
```
{"type": "RECORD", "stream": "gl_journal_entries", "record": {"entry_id": "32094", "creation_date": "2021-10-18T09:38:40.000000Z", "entry_date": "2021-10-15T00:00:00.000000Z", "amount": "38.33", "booking_date": "2021-10-15T00:00:00.000000Z"}, "time_extracted": "2021-10-18T09:48:41.300660Z"}

{"type": "RECORD", "stream": "gl_journal_entries", "record": {"entry_id": "32095", "creation_date": "2021-10-18T09:38:40.000000Z", "entry_date": "2021-10-15T00:00:00.000000Z", "amount": "1.67", "booking_date": "2021-10-15T00:00:00.000000Z"}, "time_extracted": "2021-10-18T09:48:41.300660Z"}

{"type": "RECORD", "stream": "gl_journal_entries", "record": {"entry_id": "32096", "creation_date": "2021-10-18T09:38:40.000000Z", "entry_date": "2021-10-15T00:00:00.000000Z", "amount": "40", "booking_date": "2021-10-15T00:00:00.000000Z"}, "time_extracted": "2021-10-18T09:48:41.300660Z"}

{"type": "RECORD", "stream": "gl_journal_entries", "record": {"entry_id": "32097", "creation_date": "2021-10-18T09:38:41.000000Z", "entry_date": "2021-10-13T00:00:00.000000Z", "amount": "20", "booking_date": "2021-10-13T00:00:00.000000Z"}, "time_extracted": "2021-10-18T09:48:41.300660Z"}

{"type": "RECORD", "stream": "gl_journal_entries", "record": {"entry_id": "32098", "creation_date": "2021-10-18T09:38:41.000000Z", "entry_date": "2021-10-13T00:00:00.000000Z", "amount": "18.33", "booking_date": "2021-10-13T00:00:00.000000Z"}, "time_extracted": "2021-10-18T09:48:41.300660Z"}

{"type": "RECORD", "stream": "gl_journal_entries", "record": {"entry_id": "32099", "creation_date": "2021-10-18T09:38:41.000000Z", "entry_date": "2021-10-13T00:00:00.000000Z", "amount": "1.67", "booking_date": "2021-10-13T00:00:00.000000Z"}, "time_extracted": "2021-10-18T09:48:41.300660Z"}

{"type": "RECORD", "stream": "gl_journal_entries", "record": {"entry_id": "32100", "creation_date": "2021-10-18T09:38:41.000000Z", "entry_date": "2021-10-15T00:00:00.000000Z", "amount": "40", "booking_date": "2021-10-15T00:00:00.000000Z"}, "time_extracted": "2021-10-18T09:48:41.300660Z"}

{"type": "RECORD", "stream": "gl_journal_entries", "record": {"entry_id": "32101", "creation_date": "2021-10-18T09:38:41.000000Z", "entry_date": "2021-10-15T00:00:00.000000Z", "amount": "40", "booking_date": "2021-10-15T00:00:00.000000Z"}, "time_extracted": "2021-10-18T09:48:41.300660Z"}

```
 
# Rollback steps
 - revert this branch
