### PR TITLE
version bump to v2.2.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.0
+  * Updates `gl_journal_entries` replication key to `creation_date` to capture entries with reversed transactions [#56](https://github.com/singer-io/tap-mambu/pull/56)
+
 ## 2.1.1
   * Query `installments` endpoint correctly using the `start_date` instead of bookmarked value [#54](https://github.com/singer-io/tap-mambu/pull/54)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='2.1.1',
+      version='2.2.0',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tests/base.py
+++ b/tests/base.py
@@ -204,7 +204,7 @@ class MambuBaseTest(unittest.TestCase):
                 },
                 self.REPLICATION_METHOD: "INCREMENTAL",
                 self.REPLICATION_KEYS: {
-                    "booking_date"
+                    "creation_date"
                 }
             },
             "activities": {


### PR DESCRIPTION
# Description of change
## 2.2.0
  * Updates `gl_journal_entries` replication key to `creation_date` to capture entries with reversed transactions [#56](https://github.com/singer-io/tap-mambu/pull/56)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
