### PR TITLE
Fix audit trail duplicated records

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ This tap:
 - Replication strategy: Incremental (query all, filter results)
   - Bookmark query field: occurred_at
   - Bookmark: occurred_at (date-time)
-  - Sort by: occurred_at:DESC
+  - Sort by: occurred_at:ASC
 - Transformations: Fields camelCase to snake_case
 
 ## Quick Start

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -168,7 +168,6 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
     record_count = limit # Initialize, reset for each API call
 
     # Initialize next_max_date and number_last_occurrence parameters used in the request for audit_trail
-
     next_max_date = static_params['occurred_at[gte]'] if stream_name == 'audit_trail' else None
 
     while record_count == limit: # break out of loop when record_count < limit (or not data returned)

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -143,10 +143,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
     last_integer = None
     number_last_occurrence = 0
     if bookmark_type == 'integer':
-        if stream_name == 'audit_trail':
-            last_integer, number_last_occurrence = get_bookmark(state, stream_name, sub_type, (0, 0))
-        else:
-            last_integer = get_bookmark(state, stream_name, sub_type, 0)
+        last_integer = get_bookmark(state, stream_name, sub_type, 0)
         max_bookmark_value = last_integer
     else:
         if stream_name == 'audit_trail':

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -141,12 +141,18 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
     # Get the latest bookmark for the stream and set the last_integer/datetime
     last_datetime = None
     last_integer = None
-    max_bookmark_value = None
+    number_last_occurrence = 0
     if bookmark_type == 'integer':
-        last_integer = get_bookmark(state, stream_name, sub_type, 0)
+        if stream_name == 'audit_trail':
+            last_integer, number_last_occurrence = get_bookmark(state, stream_name, sub_type, (0, 0))
+        else:
+            last_integer = get_bookmark(state, stream_name, sub_type, 0)
         max_bookmark_value = last_integer
     else:
-        last_datetime = get_bookmark(state, stream_name, sub_type, start_date)
+        if stream_name == 'audit_trail':
+            last_datetime, number_last_occurrence = get_bookmark(state, stream_name, sub_type, (start_date, 0))
+        else:
+            last_datetime = get_bookmark(state, stream_name, sub_type, start_date)
         max_bookmark_value = last_datetime
 
     write_schema(catalog, stream_name)
@@ -162,9 +168,8 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
     record_count = limit # Initialize, reset for each API call
 
     # Initialize next_max_date and number_last_occurrence parameters used in the request for audit_trail
-    if stream_name == 'audit_trail':
-        next_max_date = static_params['occurred_at[lte]']
-        number_last_occurrence = 0
+
+    next_max_date = static_params['occurred_at[gte]'] if stream_name == 'audit_trail' else None
 
     while record_count == limit: # break out of loop when record_count < limit (or not data returned)
         params = {
@@ -178,7 +183,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
             del params['limit']
             params['from'] = number_last_occurrence
             params['size'] = limit
-            params['occurred_at[lte]'] = next_max_date
+            params['occurred_at[gte]'] = next_max_date
 
         if bookmark_query_field:
             if bookmark_type == 'datetime':
@@ -231,7 +236,7 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
             transformed_data = transform_json(data, stream_name)
         elif data_key in data:
             transformed_data = transform_json(data, data_key)[data_key]
-      
+
         if stream_name == 'activities':
             transformed_data = transform_activities(transformed_data)
 
@@ -334,9 +339,10 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
     # Update the state with the max_bookmark_value for the stream
     if bookmark_field:
         write_bookmark(state,
-                        stream_name,
-                        sub_type,
-                        max_bookmark_value)
+                       stream_name,
+                       sub_type,
+                       max_bookmark_value if stream_name != 'audit_trail'
+                       else (max_bookmark_value, number_last_occurrence))
 
     # Return total_records across all batches
     return total_records
@@ -789,7 +795,7 @@ def sync(client, config, catalog, state):
             'id_fields': [],
             'apikey_type': 'audit',
             'params': {
-                'sort_order': 'desc',
+                'sort_order': 'asc',
                 'occurred_at[gte]': '{audit_trail_from_dt_str}',
                 'occurred_at[lte]': '{audit_trail_to_dt_str}'
             },
@@ -878,7 +884,7 @@ def sync(client, config, catalog, state):
                 if stream_name == 'audit_trail':
                     now_date_str = strftime(utils.now())
                     audit_trail_from_dttm_str = get_bookmark(
-                        state, 'audit_trail', sub_type, start_date)
+                        state, 'audit_trail', sub_type, (start_date, 0))[0]
                     audit_trail_from_dt_str = transform_datetime(
                         audit_trail_from_dttm_str)
                     audit_trail_from_param = endpoint_config.get(

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -147,7 +147,9 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
         max_bookmark_value = last_integer
     else:
         if stream_name == 'audit_trail':
-            last_datetime, number_last_occurrence = get_bookmark(state, stream_name, sub_type, (start_date, 0))
+            audit_trail_bookmark = get_bookmark(state, stream_name, sub_type, [start_date, 0])
+            last_datetime, number_last_occurrence = audit_trail_bookmark if type(audit_trail_bookmark) == list \
+                else (audit_trail_bookmark, 0)
         else:
             last_datetime = get_bookmark(state, stream_name, sub_type, start_date)
         max_bookmark_value = last_datetime
@@ -878,8 +880,9 @@ def sync(client, config, catalog, state):
 
                 if stream_name == 'audit_trail':
                     now_date_str = strftime(utils.now())
-                    audit_trail_from_dttm_str = get_bookmark(
-                        state, 'audit_trail', sub_type, (start_date, 0))[0]
+                    audit_trail_bookmark = get_bookmark(state, 'audit_trail', sub_type, start_date)
+                    audit_trail_from_dttm_str = audit_trail_bookmark[0] if type(audit_trail_bookmark) == list \
+                        else audit_trail_bookmark
                     audit_trail_from_dt_str = transform_datetime(
                         audit_trail_from_dttm_str)
                     audit_trail_from_param = endpoint_config.get(


### PR DESCRIPTION
# Description of change
Just for audit_trail stream:
- added `number_last_occurrence` value in bookmark state and use this value to remove duplicates
- changed the sorting order from descending to ascending

As it is right now, the records with the `occurred_at = <bookmarked_field_value>` get duplicated due to using `>=` instead of `>` when filtering the records.

This PR solves this problem by saving the last occurrence number of the bookmarked value and use it as offset in the next API call.

 
# Risks
 - if the `number_last_occurrence > 9500` the API will return `400` as it's stated in the Mambu's Docs.


# Test

**Json snippet without any code changes (last 6 records) - _bad output_**
State used: `{"bookmarks": {"audit_trail": "2021-10-27T10:24:13.016Z"}}`

```
{"type": "RECORD", "stream": "audit_trail", "record": {"occurred_at": "2021-10-27T10:24:13.437000Z", "response_code": 200.0}}
{"type": "RECORD", "stream": "audit_trail", "record": {"occurred_at": "2021-10-27T10:24:13.288000Z", "response_code": 200.0}}
{"type": "RECORD", "stream": "audit_trail", "record": {"occurred_at": "2021-10-27T10:24:13.201000Z", "response_code": 200.0}}
{"type": "RECORD", "stream": "audit_trail", "record": {"occurred_at": "2021-10-27T10:24:13.108000Z", "response_code": 200.0}}
{"type": "RECORD", "stream": "audit_trail", "record": {"occurred_at": "2021-10-27T10:24:13.016000Z", "response_code": 200.0}} <----- duplicate
{"type": "RECORD", "stream": "audit_trail", "record": {"occurred_at": "2021-10-27T10:24:13.016000Z", "response_code": 200.0}} <----- duplicate
```
The last 2 records are duplicate not because they have the same information, but because they have the same `occurred_at` as the bookmarked value, meaning that these two records have already been fetched before.

**Json snippet with the code changes (first 6 records, because of the sorting change) - _desired output_**
State used: `{"bookmarks": {"audit_trail": ["2021-10-27T10:24:13.016Z", 2]}}`

```
{"type": "RECORD", "stream": "audit_trail", "record": {"occurred_at": "2021-10-27T10:24:13.108000Z", "response_code": 200.0}}
{"type": "RECORD", "stream": "audit_trail", "record": {"occurred_at": "2021-10-27T10:24:13.201000Z", "response_code": 200.0}}
{"type": "RECORD", "stream": "audit_trail", "record": {"occurred_at": "2021-10-27T10:24:13.288000Z", "response_code": 200.0}}
{"type": "RECORD", "stream": "audit_trail", "record": {"occurred_at": "2021-10-27T10:24:13.437000Z", "response_code": 200.0}}
{"type": "RECORD", "stream": "audit_trail", "record": {"occurred_at": "2021-10-27T10:24:13.582000Z", "response_code": 200.0}}
{"type": "RECORD", "stream": "audit_trail", "record": {"occurred_at": "2021-10-27T10:24:13.701000Z", "response_code": 200.0}}
```
 
# Rollback steps
 - revert this branch