### PR TITLE
Bump to v2.3.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.0
+  * Added `original_account_key` field to the `loan_accounts` stream [#60](https://github.com/singer-io/tap-mambu/pull/60)
+  * Fix audit trail duplicated records [#59](https://github.com/singer-io/tap-mambu/pull/59)
+
 ## 2.2.0
   * Updates `gl_journal_entries` replication key to `creation_date` to capture entries with reversed transactions [#56](https://github.com/singer-io/tap-mambu/pull/56)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='2.2.0',
+      version='2.3.0',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Bump to v2.3.0 and update changelog

  * Added `original_account_key` field to the `loan_accounts` stream #60 
  * Fix audit trail duplicated records #59 

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
