### PR TITLE
Verison 2.3.1 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.1
+  * Adjust bookmarking of `loan_accounts` to use `modified_date` *or* `account_appraisal_date` [#62](https://github.com/singer-io/tap-mambu/pull/62)
+  * Stream `loan_accounts` and child stream `loan_repayments` refactored into new pattern
+
 ## 2.3.0
   * Added `original_account_key` field to the `loan_accounts` stream [#60](https://github.com/singer-io/tap-mambu/pull/60)
   * Fix audit trail duplicated records [#59](https://github.com/singer-io/tap-mambu/pull/59)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='2.3.0',
+      version='2.3.1',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Version 2.3.1 bump for #62 

# Manual QA steps
 - Reviewed code visually, trusting tap-tester tests for general bookmark behavior because the stream is under test.
 
# Risks
 - Medium, this is a rather large refactor, but from visual review, obvious nuanced scenarios with state and bookmarking seem to be fine.
 
# Rollback steps
 - revert this branch, release new patch version
