### PR TITLE
Version 2.3.2 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.2
+  * Fix issue with handling the `account_appraisal_date` for `loan_accounts` stream. [#64](https://github.com/singer-io/tap-mambu/pull/64)
+
 ## 2.3.1
   * Adjust bookmarking of `loan_accounts` to use `modified_date` *or* `account_appraisal_date` [#62](https://github.com/singer-io/tap-mambu/pull/62)
   * Stream `loan_accounts` and child stream `loan_repayments` refactored into new pattern

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='2.3.1',
+      version='2.3.2',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Releasing #64 

# Manual QA steps
 - Ran through the tap-tester tests after fix. I'm trusting that the bookmarks and start_date tests sufficiently cover the replication key bookmarking and usage
 
# Risks
 - Low
 
# Rollback steps
 - revert #64. release new patch version
