### PR TITLE
Version 2.3.3 and Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.3
+  * Enable sorting of `gl_journal_entries` response to prevent missing records due to pagination [#66](https://github.com/singer-io/tap-mambu/pull/66)
+
 ## 2.3.2
   * Fix issue with handling the `account_appraisal_date` for `loan_accounts` stream. [#64](https://github.com/singer-io/tap-mambu/pull/64)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='2.3.2',
+      version='2.3.3',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Releasing PR #66 in version 2.3.3

# Manual QA steps
 - Ran through the tests and confirmed the bookmarks test still works and the gl_journal_entries stream has data.
 
# Risks
 - Low, the bookmark isn't saved until after the pagination has finished entirely, so this will just change the order in which records go into the target, it should prevent a tap from resuming in case of interruption in any way beyond what it currently does.
 
# Rollback steps
 - revert #66 
