### PR TITLE
Version 2.5.1 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.1
+  * Hotfix for edge cases introduced in version 2.5.0 [#76](https://github.com/singer-io/tap-mambu/pull/76)
+
 ## 2.5.0
   * New stream, finished non-breaking refactor, new fields [#74](https://github.com/singer-io/tap-mambu/pull/74)
     * Added new stream `interest_accrual_breakdown`

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='2.5.0',
+      version='2.5.1',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Release branch for hotfix for 2.5.0. Pr #76 

# Manual QA steps
 - Visually reviewed and confirmed it matched the lines broken.
 - The extra safety check for a null reference was approved based on visual approval of defensive coding practices and running unit tests
 
# Risks
 - Low, 2.5.0 is broken for certain streams/edge cases
 
# Rollback steps
 - revert #76 and #75, and implement full fix in 2.5.2.
