### PR TITLE
Version 2.5.2 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.2
+  * Hotfix for audit_trail bookmarking issue [#79](https://github.com/singer-io/tap-mambu/pull/79)
+
 ## 2.5.1
   * Hotfix for edge cases introduced in version 2.5.0 [#76](https://github.com/singer-io/tap-mambu/pull/76)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='2.5.1',
+      version='2.5.2',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Release for PR #79 

# Manual QA steps
 - None, relying on automation in this case and testing of the Mambu team.
 
# Risks
 - Low, it's currently prohibiting audit_trail from syncing, and this change is isolated to audit_trail code
 
# Rollback steps
 - apply another hotfix
