### PR TITLE
Version 3.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json tap_mambu/schemas/*.json
+            stitch-validate-json tap_mambu/helpers/schemas/*.json
       - run:
           when: always
           name: 'Unit Tests'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.0.0
+  * Major schema refactoring, V2 API upgrade [#77](https://github.com/singer-io/tap-mambu/pull/77)
+    * Finishes structural refactoring of the tap to generator-processor pattern
+    * Upgrades all streams with a comparable endpoint to V2 API
+    * Updates all schemas to match current documentation
+    * Adds schema extraction script to repo for generating schemas from Swagger specs
+
 ## 2.5.2
   * Hotfix for audit_trail bookmarking issue [#79](https://github.com/singer-io/tap-mambu/pull/79)
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include LICENSE
-include tap_mambu/schemas/*.json
+include tap_mambu/helpers/schemas/*.json

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='2.5.2',
+      version='3.0.0',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(name='tap-mambu',
       packages=find_packages(),
       package_data={
           'tap_mambu': [
-              'schemas/*.json'
+              'helpers/schemas/*.json'
           ]
       })


### PR DESCRIPTION
# Description of change
Release PR for the changes in #77 

This is a major version bump due to the schema changes that came from updating the streams to V2 API.

# Manual QA steps
 - N/A Accounted for in #77 
 
# Risks
 - It's a major version bump, so if any breaking change was missed, it will need queued for the next major version.
 
# Rollback steps
 - Not easily, could mark the 3.x path as deprecated, revert #77 and continue on the 2.X path, but that isn't very desirable.