### PR TITLE
Version 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.1
+  * Marks Python 3.9 or greater as required to run the tap to support the multithreading pattern [#89](https://github.com/singer-io/tap-mambu/pull/89)
+
 ## 3.1.0
   * Implements initial use cases of multithreaded requests for certain streams [#84](https://github.com/singer-io/tap-mambu/pull/84)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='3.1.0',
+      version='3.1.1',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Bumping version for #89 

# Manual QA steps
 - None, this is already running under 3.9.6 successfully
 
# Risks
 - Low
 
# Rollback steps
 - revert #89 and release new patch version
