### PR TITLE
Version 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.2
+  * Hotfix for deposit_accounts bookmarking issue [#91](https://github.com/singer-io/tap-mambu/pull/91)
+
 ## 3.1.1
   * Marks Python 3.9 or greater as required to run the tap to support the multithreading pattern [#89](https://github.com/singer-io/tap-mambu/pull/89)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='3.1.1',
+      version='3.1.2',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Bumping for version #91 

# Manual QA steps
 - None, `endpoint_sorting_criteria` now matches the bookmark.
 
# Risks
 - Low
 
# Rollback steps
 - revert #91 and release new patch version
