### PR TITLE
Time zone endpoint version downgrade

### DIFF
--- a/tap_mambu/helpers/datetime_utils.py
+++ b/tap_mambu/helpers/datetime_utils.py
@@ -24,7 +24,7 @@ _datetime_formats = [
 
 def get_timezone_info(client: MambuClient):
     global _timezone
-    response = client.request(method="GET", path="setup/organization", version="v2")
+    response = client.request(method="GET", path="settings/organization", version="v1")
     _timezone = timezone(response.get("timeZoneID"))
 
 


### PR DESCRIPTION
# Description of change
We have changed the endpoint version that it's used to get the client timezone because the client has to give some extra priviliges to the api consumer in order to use the v2. The v1 sends the same information (regarding the time zone) as the v2, without the extra steps.

# Rollback steps
 - revert this branch
