### PR TITLE
Version 3.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.4
+  * Use v1 API endpoint to get a user's timezone since v2 requires extra privileges [#96](https://github.com/singer-io/tap-mambu/pull/96)
+
 ## 3.1.3
   * Improve handling of timezones [#85](https://github.com/singer-io/tap-mambu/pull/85)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='3.1.3',
+      version='3.1.4',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Bumping version for #96 

# Manual QA steps
 - None, endpoint returns the same timezone data.
 
# Risks
 - Low
 
# Rollback steps
 - revert #96 and release new patch version
