### PR TITLE
Bump version to 3.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.1.5
-  * Calulate `time_extracted` field on multithreaded streams directly before a record is written to stdout to fix an issue where the field was not was not populating
+  * Calulate `time_extracted` field on multithreaded streams directly before a record is written to stdout to fix an issue where the field was not was not populating [#98](https://github.com/singer-io/tap-mambu/pull/98)
 
 ## 3.1.4
   * Use v1 API endpoint to get a user's timezone since v2 requires extra privileges [#96](https://github.com/singer-io/tap-mambu/pull/96)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.5
+  * Calulate `time_extracted` field on multithreaded streams directly before a record is written to stdout to fix an issue where the field was not was not populating
+
 ## 3.1.4
   * Use v1 API endpoint to get a user's timezone since v2 requires extra privileges [#96](https://github.com/singer-io/tap-mambu/pull/96)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='3.1.4',
+      version='3.1.5',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Bumping version for #98

# Manual QA steps
 - None, `time_extracted` in purely informational
 
# Risks
 - Low
 
# Rollback steps
 - revert #98 and release new patch version