### PR TITLE
Lowered backoff max retries, limited number of threads created

### DIFF
--- a/mambu_tests/multithreading/test_requests_pool.py
+++ b/mambu_tests/multithreading/test_requests_pool.py
@@ -11,7 +11,7 @@ def test_queue_request(mock_thread_pool_exec_submit):
 
     # test if the submit params are the same as queue_request params
     mock_thread_pool_exec_submit.assert_called_once_with(MultithreadedRequestsPool.run, 'client', 'stream_name',
-                                                         'stream_path', 'GET', 'v2', '', {}, {})
+                                                         'stream_path', 'GET', 'v2', '', {}, {}, False)
 
 
 @patch("tap_mambu.helpers.client.MambuClient.request")
@@ -73,7 +73,7 @@ def test_run(mock_multithreaded_request_pool_run, mock_performance_metrics, mock
         mock_multithreaded_request_pool_run.assert_any_call(client, stream_name,
                                                             endpoint_paths[idx], api_methods[idx],
                                                             endpoint_api_version, endpoint_api_key_type,
-                                                            endpoint_body, endpoint_params[idx])
+                                                            endpoint_body, endpoint_params[idx], False)
         # test if the client request method is called with the correct params
         mock_client_request.assert_any_call(method=api_methods[idx],
                                             path=endpoint_paths[idx],
@@ -81,7 +81,8 @@ def test_run(mock_multithreaded_request_pool_run, mock_performance_metrics, mock
                                             apikey_type=endpoint_api_key_type,
                                             params=f'offset={endpoint_params[idx]["offset"]}&limit={endpoint_params[idx]["limit"]}',
                                             endpoint=stream_name,
-                                            json=endpoint_body)
+                                            json=endpoint_body,
+                                            full_response=False)
 
     # test if the performance metrics collector is called
     mock_performance_metrics.assert_called_with(metric_name='generator')

--- a/mambu_tests/tap_generators/__init__.py
+++ b/mambu_tests/tap_generators/__init__.py
@@ -1,9 +1,10 @@
-from mock import MagicMock
-
+from tap_mambu.tap_generators.multithreaded_offset_generator import MultithreadedOffsetGenerator
 from tap_mambu.tap_generators.child_generator import ChildGenerator
 from ..constants import config_json
 from tap_mambu.helpers.generator_processor_pairs import get_generator_processor_for_stream
-from ..helpers import ClientWithDataMock, ClientMock
+from ..helpers import ClientWithDataMock, ClientMock, ClientWithDataMultithreadedMock
+
+MULTITHREADED_STREAMS_WITHOUT_PAGINATION_DETAILS_ON = ['activities', 'interest_accrual_breakdown']
 
 
 def setup_generator_base_test(stream_name, client_mock=None, with_data=False, custom_data=None,
@@ -15,9 +16,16 @@ def setup_generator_base_test(stream_name, client_mock=None, with_data=False, cu
         if client_mock is None:
             client = ClientMock(int(config_json.get("page_size", 200)))
             if with_data:
-                client = ClientWithDataMock(int(config_json.get("page_size", 200)), custom_data=custom_data,
-                                            offset_field=offset_field, limit_field=limit_field,
-                                            bookmark_field=bookmark_field)
+                if issubclass(generator_class, MultithreadedOffsetGenerator) and \
+                        stream_name not in MULTITHREADED_STREAMS_WITHOUT_PAGINATION_DETAILS_ON:
+                    client = ClientWithDataMultithreadedMock(int(config_json.get("page_size", 200)),
+                                                             custom_data=custom_data,
+                                                             offset_field=offset_field, limit_field=limit_field,
+                                                             bookmark_field=bookmark_field)
+                else:
+                    client = ClientWithDataMock(int(config_json.get("page_size", 200)), custom_data=custom_data,
+                                                offset_field=offset_field, limit_field=limit_field,
+                                                bookmark_field=bookmark_field)
 
         generator = generator_class(stream_name=stream_name,
                                     client=client,

--- a/mambu_tests/tap_generators/test_activities_generator.py
+++ b/mambu_tests/tap_generators/test_activities_generator.py
@@ -1,4 +1,3 @@
-import mock
 from singer import utils
 from . import setup_generator_base_test
 

--- a/mambu_tests/tap_generators/test_generators.py
+++ b/mambu_tests/tap_generators/test_generators.py
@@ -1,15 +1,12 @@
-import inspect
-import logging
 import os
+import inspect
+
 from copy import deepcopy
 from datetime import datetime
-
 from unittest.mock import MagicMock
-
 from pytz import timezone
 
 from tap_mambu.helpers import transform_json, convert
-from tap_mambu.helpers.generator_processor_pairs import get_available_streams
 from tap_mambu.tap_generators.generator import TapGenerator
 from tap_mambu.tap_generators.multithreaded_bookmark_generator import MultithreadedBookmarkDayByDayGenerator, \
     MultithreadedBookmarkGenerator
@@ -150,24 +147,8 @@ def test_generator_bookmark_flow():
             "client": "N/A", "activity": {
                 "id": index, "timestamp": f"2022-06-07T00:00:00.{index:06d}Z-07:00"}
         } for index in range(400)],
-        # "branches": ["lastModifiedDate"],
-        # "centres": ["lastModifiedDate"],
-        # "clients": ["lastModifiedDate"],
-        # "communications": ["creationDate"],
-        # "credit_arrangements": ["lastModifiedDate"],
-        # "deposit_accounts": ["lastModifiedDate"],
-        # "deposit_products": ["lastModifiedDate"],
-        # "gl_accounts": ["lastModifiedDate"],
-        # "gl_journal_entries": ["creationDate"],
-        # "groups": ["lastModifiedDate"],
-        # "deposit_transactions": ["creationDate"],
-        # "installments": ["lastPaidDate"],
-        # "interest_accrual_breakdown": ["creationDate"],
-        # "loan_products": ["lastModifiedDate"],
-        # "loan_transactions": ["creationDate"],
-        # "tasks": ["lastModifiedDate"],
-        # "users": ["lastModifiedDate"],
     }
+
     for stream_name in stream_bookmarks:
         generators = setup_generator_base_test(stream_name, with_data=True,
                                                bookmark_field=stream_bookmarks[stream_name],

--- a/tap_mambu/helpers/client.py
+++ b/tap_mambu/helpers/client.py
@@ -180,7 +180,8 @@ class MambuClient(object):
                           (Server5xxError, ConnectionError, Server429Error),
                           max_tries=7,
                           factor=3)
-    def request(self, method, path=None, url=None, json=None, version=None, apikey_type=None, **kwargs):
+    def request(self, method, path=None, url=None, json=None,
+                version=None, apikey_type=None, full_response=False, **kwargs):
         if not self.__verified:
             self.__verified = self.check_access()
 
@@ -230,4 +231,4 @@ class MambuClient(object):
         if response.status_code != 200:
             raise_for_error(response)
 
-        return response.json()
+        return response if full_response else response.json()

--- a/tap_mambu/helpers/client.py
+++ b/tap_mambu/helpers/client.py
@@ -178,8 +178,8 @@ class MambuClient(object):
 
     @backoff.on_exception(backoff.expo,
                           (Server5xxError, ConnectionError, Server429Error),
-                          max_tries=7,
-                          factor=3)
+                          max_tries=3,
+                          factor=4)
     def request(self, method, path=None, url=None, json=None,
                 version=None, apikey_type=None, full_response=False, **kwargs):
         if not self.__verified:

--- a/tap_mambu/tap_generators/activities_generator.py
+++ b/tap_mambu/tap_generators/activities_generator.py
@@ -11,7 +11,7 @@ class ActivitiesGenerator(MultithreadedBookmarkDayByDayGenerator):
         self.endpoint_api_version = "v1"
 
         self.endpoint_params["from"] = datetime_to_utc_str(str_to_localized_datetime(
-                    get_bookmark(self.state, self.stream_name, self.sub_type, self.start_date)))[:10]
+            get_bookmark(self.state, self.stream_name, self.sub_type, self.start_date)))[:10]
         self.endpoint_params["to"] = datetime_to_utc_str(utc_now())[:10]
         self.endpoint_bookmark_field = "timestamp"
 
@@ -30,3 +30,6 @@ class ActivitiesGenerator(MultithreadedBookmarkDayByDayGenerator):
 
     def compare_bookmark_values(self, a, b):
         return a < b
+
+    def get_first_batch_and_total_records(self):
+        return [], self.batch_limit

--- a/tap_mambu/tap_generators/interest_accrual_breakdown_generator.py
+++ b/tap_mambu/tap_generators/interest_accrual_breakdown_generator.py
@@ -25,3 +25,6 @@ class InterestAccrualBreakdownGenerator(MultithreadedBookmarkDayByDayGenerator):
         super(InterestAccrualBreakdownGenerator, self).prepare_batch_params()
         # look in db for the reason DateTimes don't work, but Dates do
         self.endpoint_filter_criteria[0]["value"] = datetime_to_utc_str(self.endpoint_intermediary_bookmark_value)[:10]
+
+    def get_first_batch_and_total_records(self):
+        return [], self.batch_limit

--- a/tap_mambu/tap_generators/multithreaded_bookmark_generator.py
+++ b/tap_mambu/tap_generators/multithreaded_bookmark_generator.py
@@ -3,6 +3,7 @@ import time
 
 from copy import deepcopy
 from singer import get_logger
+from requests import Response
 
 from .multithreaded_offset_generator import MultithreadedOffsetGenerator
 from ..helpers import transform_json, convert
@@ -37,9 +38,14 @@ class MultithreadedBookmarkGenerator(MultithreadedOffsetGenerator):
 
     def queue_batches(self):
         # prepare batches (with self.limit for each of them until we reach batch_limit)
-        futures = list()
         original_offset = self.offset
-        for offset in range(0, self.batch_limit, self.artificial_limit):
+        futures, total_records = self.get_first_batch_and_total_records()
+        min_offset = 0
+        if futures:
+            min_offset = self.artificial_limit
+
+        max_offset = min(total_records + self.artificial_limit, self.batch_limit)
+        for offset in range(min_offset, max_offset, self.artificial_limit):
             self.offset = original_offset + offset
             self.prepare_batch()
             # send batches to multithreaded_requests_pool
@@ -58,7 +64,11 @@ class MultithreadedBookmarkGenerator(MultithreadedOffsetGenerator):
         for future in futures:
             while not future.done():
                 time.sleep(0.1)
+
             result = future.result()
+            if type(result) is Response:
+                result = result.json()
+
             transformed_batch = self.transform_batch(transform_json(result, self.stream_name))
             temp_buffer = set(transformed_batch)
 

--- a/tap_mambu/tap_generators/multithreaded_offset_generator.py
+++ b/tap_mambu/tap_generators/multithreaded_offset_generator.py
@@ -1,6 +1,7 @@
 import time
 from copy import deepcopy
 from threading import Thread
+from requests import Response
 
 import backoff
 from singer import get_logger
@@ -59,10 +60,37 @@ class MultithreadedOffsetGenerator(TapGenerator):
                 self.end_of_file = True
             time.sleep(0.1)
 
+    def _queue_first_batch(self):
+        self.prepare_batch()
+        params = deepcopy(self.params)
+        params["paginationDetails"] = "ON"
+        future_request = MultithreadedRequestsPool.queue_request(self.client, self.stream_name,
+                                                                 self.endpoint_path, self.endpoint_api_method,
+                                                                 self.endpoint_api_version,
+                                                                 self.endpoint_api_key_type,
+                                                                 deepcopy(self.endpoint_body),
+                                                                 params,
+                                                                 True)
+        self.offset += self.artificial_limit
+        return future_request
+
+    def _get_number_of_records(self, future_request):
+        while not future_request.done():
+            time.sleep(0.1)
+        return int(future_request.result().headers['items-total'])
+
+    def get_first_batch_and_total_records(self):
+        first_batch = self._queue_first_batch()
+        if first_batch:
+            return [first_batch], self._get_number_of_records(first_batch)
+        return [], self.batch_limit
+
     def queue_batches(self):
         # prepare batches (with self.limit for each of them until we reach batch_limit)
-        futures = list()
-        while len(self.buffer) + len(futures) * self.limit <= self.batch_limit:
+        futures, total_records = self.get_first_batch_and_total_records()
+
+        max_offset = min(total_records + self.artificial_limit, self.batch_limit)
+        while len(self.buffer) + len(futures) * self.limit <= max_offset:
             self.prepare_batch()
             # send batches to multithreaded_requests_pool
             futures.append(MultithreadedRequestsPool.queue_request(self.client, self.stream_name,
@@ -82,7 +110,11 @@ class MultithreadedOffsetGenerator(TapGenerator):
         for future in futures:
             while not future.done():
                 time.sleep(0.1)
+
             result = future.result()
+            if type(result) is Response:
+                result = result.json()
+
             transformed_batch = self.transform_batch(transform_json(result, self.stream_name))
             temp_buffer = set(transformed_batch)
 


### PR DESCRIPTION
# Description of change
The changes:
- used paginationDetails "ON" on the first call for each big batch in order to create the right number of threads
- lowered the `backoff.on_exception` max_retries to `3` and increased the `factor` value to `4`
- fixed a bug which, if there was a HTTP 500 error, the error was raised but the execution was blocked in an infinite loop
- updated the README file

 
# Rollback steps
 - revert this branch
