### PR TITLE
TDL-21365 Update custom field handling and custom fields schemas

### DIFF
--- a/tap_mambu/helpers/schemas/branches.json
+++ b/tap_mambu/helpers/schemas/branches.json
@@ -197,38 +197,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/centres.json
+++ b/tap_mambu/helpers/schemas/centres.json
@@ -143,38 +143,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/clients.json
+++ b/tap_mambu/helpers/schemas/clients.json
@@ -457,38 +457,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/communications.json
+++ b/tap_mambu/helpers/schemas/communications.json
@@ -131,38 +131,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/credit_arrangements.json
+++ b/tap_mambu/helpers/schemas/credit_arrangements.json
@@ -129,38 +129,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/custom_field_sets.json
+++ b/tap_mambu/helpers/schemas/custom_field_sets.json
@@ -266,38 +266,18 @@
       }
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/deposit_accounts.json
+++ b/tap_mambu/helpers/schemas/deposit_accounts.json
@@ -660,38 +660,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/deposit_products.json
+++ b/tap_mambu/helpers/schemas/deposit_products.json
@@ -934,38 +934,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/deposit_transactions.json
+++ b/tap_mambu/helpers/schemas/deposit_transactions.json
@@ -835,38 +835,18 @@
       "format": "date-time"
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/gl_accounts.json
+++ b/tap_mambu/helpers/schemas/gl_accounts.json
@@ -99,38 +99,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/gl_journal_entries.json
+++ b/tap_mambu/helpers/schemas/gl_journal_entries.json
@@ -274,38 +274,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/groups.json
+++ b/tap_mambu/helpers/schemas/groups.json
@@ -247,38 +247,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/index_rate_sources.json
+++ b/tap_mambu/helpers/schemas/index_rate_sources.json
@@ -33,38 +33,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/installments.json
+++ b/tap_mambu/helpers/schemas/installments.json
@@ -415,38 +415,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/interest_accrual_breakdown.json
+++ b/tap_mambu/helpers/schemas/interest_accrual_breakdown.json
@@ -193,38 +193,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/loan_accounts.json
+++ b/tap_mambu/helpers/schemas/loan_accounts.json
@@ -1439,38 +1439,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/loan_products.json
+++ b/tap_mambu/helpers/schemas/loan_products.json
@@ -1831,38 +1831,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/loan_transactions.json
+++ b/tap_mambu/helpers/schemas/loan_transactions.json
@@ -630,38 +630,18 @@
       "format": "date-time"
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/tasks.json
+++ b/tap_mambu/helpers/schemas/tasks.json
@@ -90,38 +90,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tap_mambu/helpers/schemas/users.json
+++ b/tap_mambu/helpers/schemas/users.json
@@ -233,38 +233,18 @@
       ]
     },
     "custom_fields": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "field_set_id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "id": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "additionalProperties": true,
+        "properties": {}
+      }
     }
   }
 }

--- a/tests/unittests/test_transform.py
+++ b/tests/unittests/test_transform.py
@@ -5,25 +5,29 @@ from tap_mambu.helpers import transform_json
 class TestTransformJson(unittest.TestCase):
 
     def test_transform_json_handles_dictionary_custom_fields(self):
-        expected = [{'custom_fields': [{"_custom_1" : {"id": '1'}}],
-                     'id': '1'}]
+        expected = [{'_custom_1': {'id': '1'},
+                     'id': '1',
+                     'custom_fields': [{'_custom_1': {'id': '1'}}]}]
         actual = transform_json([{"_custom_1" : {"id": '1'}, "id": '1'}],
                                 "my_path")
         self.assertEqual(expected, actual)
 
     def test_transform_json_handles_list_custom_fields(self):
-        expected = [{'custom_fields': [{"_custom_1" : {"id": '1'},
-                                        "_custom_2" : [{"id": '2', "index": '0'},
-                                                       {"id": '3', "index": '1'}],
-                                        }],
-                     'id': '1'}]
-
+        # the `_` fields will be stripped by the transformer
+        expected = [{'_custom_1': {'id': '1'},
+                     '_custom_2': [{'id': '2', 'index': '0'},
+                                   {'id': '3', 'index': '1'}],
+                     'id': '1',
+                     'custom_fields': [{'_custom_1': {'id': '1'}},
+                                       {'_custom_2': [{'id': '2', 'index': '0'},
+                                                      {'id': '3', 'index': '1'}]}
+                                        ]
+                     }]
         actual = transform_json([{"_custom_1" : {"id": '1'},
                                   "_custom_2" : [{"id": '2', "index": '0'},
                                                  {"id": '3', "index": '1'}],
                                   "id": '1'}],
                                 "my_path")
-
         self.assertEqual(expected, actual)
 
     def test_transform_no_custom_fields(self):
@@ -31,4 +35,5 @@ class TestTransformJson(unittest.TestCase):
                      'id': '1'}]
         actual = transform_json([{"id": '1'}],
                                 "my_path")
+
         self.assertEquals(expected, actual)

--- a/tests/unittests/test_transform.py
+++ b/tests/unittests/test_transform.py
@@ -5,18 +5,16 @@ from tap_mambu.helpers import transform_json
 class TestTransformJson(unittest.TestCase):
 
     def test_transform_json_handles_dictionary_custom_fields(self):
-        expected = [{'custom_fields': [{'field_set_id': '_custom_1', 'id': 'id', 'value': '1'}],
+        expected = [{'custom_fields': [{"_custom_1" : {"id": '1'}}],
                      'id': '1'}]
         actual = transform_json([{"_custom_1" : {"id": '1'}, "id": '1'}],
                                 "my_path")
         self.assertEqual(expected, actual)
 
     def test_transform_json_handles_list_custom_fields(self):
-        expected = [{'custom_fields': [{'field_set_id': '_custom_1', 'id': 'id', 'value': '1'},
-                                       {'field_set_id': '_custom_2', 'id': 'id', 'value': '2'},
-                                       {'field_set_id': '_custom_2', 'id': 'index', 'value': '0'},
-                                       {'field_set_id': '_custom_2', 'id': 'id', 'value': '3'},
-                                       {'field_set_id': '_custom_2', 'id': 'index', 'value': '1'}],
+        expected = [{'custom_fields': [{"_custom_1" : {"id": '1'},
+                                        "_custom_2" : [{"id": '2', "index": '0'},
+                                                       {"id": '3', "index": '1'}],
                      'id': '1'}]
 
         actual = transform_json([{"_custom_1" : {"id": '1'},

--- a/tests/unittests/test_transform.py
+++ b/tests/unittests/test_transform.py
@@ -15,6 +15,7 @@ class TestTransformJson(unittest.TestCase):
         expected = [{'custom_fields': [{"_custom_1" : {"id": '1'},
                                         "_custom_2" : [{"id": '2', "index": '0'},
                                                        {"id": '3', "index": '1'}],
+                                        }],
                      'id': '1'}]
 
         actual = transform_json([{"_custom_1" : {"id": '1'},


### PR DESCRIPTION
# Description of change
- Modifies custom field handling to ensure formatting is consistent with how the Mambu API functions.
- Updates schemas for streams that use custom fields to ensure persistence of correct formatting.

# Manual QA steps
 - validated with sandbox account / integration
 
# Risks
 - All streams using custom fields will cease to persist the field_set_id, id, and value keys and will instead persist new keys and values for each of their source custom fields. Those key value combinations can be arrays, which could increase the level of nesting / quantity of sub-tables downstream.
 
# Rollback steps
 - revert this branch
