### PR TITLE
TDL-24571 Set max_threads to 1

### DIFF
--- a/tap_mambu/tap_generators/clients_generator.py
+++ b/tap_mambu/tap_generators/clients_generator.py
@@ -6,7 +6,7 @@ from ..helpers.datetime_utils import str_to_localized_datetime, datetime_to_loca
 class ClientsGenerator(MultithreadedBookmarkGenerator):
     def _init_config(self):
         super()._init_config()
-        self.max_threads = 10
+        self.max_threads = 1
 
     def _init_endpoint_config(self):
         super(ClientsGenerator, self)._init_endpoint_config()

--- a/tap_mambu/tap_generators/deposit_accounts_generator.py
+++ b/tap_mambu/tap_generators/deposit_accounts_generator.py
@@ -6,7 +6,7 @@ from ..helpers.datetime_utils import datetime_to_utc_str, str_to_localized_datet
 class DepositAccountsGenerator(MultithreadedBookmarkGenerator):
     def _init_config(self):
         super()._init_config()
-        self.max_threads = 25
+        self.max_threads = 1
 
     def _init_endpoint_config(self):
         super(DepositAccountsGenerator, self)._init_endpoint_config()

--- a/tap_mambu/tap_generators/deposit_transactions_generator.py
+++ b/tap_mambu/tap_generators/deposit_transactions_generator.py
@@ -6,7 +6,7 @@ from ..helpers.datetime_utils import datetime_to_utc_str, str_to_localized_datet
 class DepositTransactionsGenerator(MultithreadedBookmarkGenerator):
     def _init_config(self):
         super()._init_config()
-        self.max_threads = 5
+        self.max_threads = 1
 
     def _init_endpoint_config(self):
         super(DepositTransactionsGenerator, self)._init_endpoint_config()

--- a/tap_mambu/tap_generators/gl_journal_entries_generator.py
+++ b/tap_mambu/tap_generators/gl_journal_entries_generator.py
@@ -6,7 +6,7 @@ from ..helpers.datetime_utils import datetime_to_utc_str, str_to_localized_datet
 class GlJournalEntriesGenerator(MultithreadedBookmarkGenerator):
     def _init_config(self):
         super()._init_config()
-        self.max_threads = 5
+        self.max_threads = 1
 
     def _init_endpoint_config(self):
         super(GlJournalEntriesGenerator, self)._init_endpoint_config()

--- a/tap_mambu/tap_generators/multithreaded_offset_generator.py
+++ b/tap_mambu/tap_generators/multithreaded_offset_generator.py
@@ -29,7 +29,7 @@ class MultithreadedOffsetGenerator(TapGenerator):
         self.end_of_file = False
         self.fetch_batch_thread = None
         self.last_batch_set = set()
-        self.max_threads = 20
+        self.max_threads = 1
 
     @staticmethod
     def check_and_get_set_reunion(a: set, b: set, lower_limit: int):


### PR DESCRIPTION
# Description of change
Effectively disable multithreading by setting max_threads to one everywhere it is defined. This will:
1) prevent conflicting searches that seem to result in discrepancies
2) ensure accurate, sequential request logging

# Manual QA steps
 - Tested with local connection
 
# Risks
 - This change will make streams slower by reducing the concurrency of threads
 
# Rollback steps
 - revert this branch
