### PR TITLE
Handle `None` values in `HashableDict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.3
+  * Handle `None` values in `HashableDict` [#109](https://github.com/singer-io/tap-mambu/pull/109)
+
 ## 4.0.2
   * Dependabot update [#106](https://github.com/singer-io/tap-mambu/pull/106)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='4.0.2',
+      version='4.0.3',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mambu/helpers/hashable_dict.py
+++ b/tap_mambu/helpers/hashable_dict.py
@@ -1,7 +1,3 @@
-import json
-import math
-
-
 class HashableDict(dict):
 
     @staticmethod
@@ -9,7 +5,11 @@ class HashableDict(dict):
         if type(value) in [dict, HashableDict]:
             return HashableDict(value).__key()
         if type(value) == list:
-            return tuple(sorted(map(HashableDict._recur_hash, value), key=lambda x: x if x is not None else -math.inf))
+            # None values are not sortable, but they are appended to the end of
+            # the list so that they are still hashed
+            sortable_values = [x for x in map(HashableDict._recur_hash, value) if x is not None]
+            none_values = [x for x in map(HashableDict._recur_hash, value) if x is None]
+            return tuple(sorted(sortable_values) + none_values)
         return value
 
     def __key(self):

--- a/tap_mambu/helpers/hashable_dict.py
+++ b/tap_mambu/helpers/hashable_dict.py
@@ -1,4 +1,5 @@
 import json
+import math
 
 
 class HashableDict(dict):
@@ -8,7 +9,7 @@ class HashableDict(dict):
         if type(value) in [dict, HashableDict]:
             return HashableDict(value).__key()
         if type(value) == list:
-            return tuple(sorted(map(HashableDict._recur_hash, value)))
+            return tuple(sorted(map(HashableDict._recur_hash, value), key=lambda x: x if x is not None else -math.inf))
         return value
 
     def __key(self):


### PR DESCRIPTION
# Description of change
This change puts `None` values at the end of a list before the list is hashed.

# Manual QA steps
 - Verified tap progresses through extraction when `None` values are present.
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
