### PR TITLE
Allow `None` in users.access.permissions list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.4
+  * Handle `None` values in `users.access.permissions` list [#110](https://github.com/singer-io/tap-mambu/pull/110)
+
 ## 4.0.3
   * Handle `None` values in `HashableDict` [#109](https://github.com/singer-io/tap-mambu/pull/109)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='4.0.3',
+      version='4.0.4',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mambu/helpers/schemas/users.json
+++ b/tap_mambu/helpers/schemas/users.json
@@ -78,7 +78,10 @@
             {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": [
+                  "null",
+                  "string"
+                ]
               }
             },
             {


### PR DESCRIPTION
# Description of change
`users.access.permissions` may have null values in its list. 
This change updates the users schema to allow null values in the list.

# Manual QA steps
 - Verified sync succeeds when there is a null value in the list
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
