### PR TITLE
Delay first bookmark writing for multithreaded streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.2.1
+  * Fix the bookmarking for multi-threaded streams [#117](https://github.com/singer-io/tap-mambu/pull/117)
+
 ## 4.2.0
   * Perfomance improvements [#113](https://github.com/singer-io/tap-mambu/pull/113)
     * Implement date windowing (default size = 1 day) and pagination for multi-threaded streams

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='4.2.0',
+      version='4.2.1',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mambu/tap_generators/multithreaded_offset_generator.py
+++ b/tap_mambu/tap_generators/multithreaded_offset_generator.py
@@ -147,7 +147,7 @@ class MultithreadedOffsetGenerator(TapGenerator):
 
             if last_sync_window_start:
                 truncated_start_date = str_to_datetime(
-                    last_sync_window_start).replace(hour=0, minute=0, second=0)
+                    last_sync_window_start).replace(hour=0, minute=0, second=0, microsecond=0)
                 start = str_to_localized_datetime(
                     datetime_to_utc_str(truncated_start_date))
             else:
@@ -163,7 +163,6 @@ class MultithreadedOffsetGenerator(TapGenerator):
                 # of current date window are processed to reduce memory pressure and improve bookmarking
                 while len(self.buffer):
                     time.sleep(1)
-                self.write_sub_stream_bookmark(datetime_to_utc_str(start))
                 self.modify_request_params(start - timedelta(minutes=5), temp)
                 final_buffer, stop_iteration = self.collect_batches(
                     self.queue_batches())
@@ -173,6 +172,7 @@ class MultithreadedOffsetGenerator(TapGenerator):
                     self.start_windows_datetime_str = start
                     start = temp
                     temp = start + timedelta(days=self.date_window_size)
+                self.write_sub_stream_bookmark(datetime_to_utc_str(start))
         else:
             final_buffer, stop_iteration = self.collect_batches(self.queue_batches())
             self.preprocess_batches(final_buffer)

--- a/tap_mambu/tap_processors/processor.py
+++ b/tap_mambu/tap_processors/processor.py
@@ -109,9 +109,6 @@ class TapProcessor(ABC):
         if str_to_localized_datetime(transformed_record[bookmark_field]) >= \
                 str_to_localized_datetime(self.last_bookmark_value):
             return True
-        else:
-            LOGGER.info(
-                f"Skipped record older than bookmark: {self.stream_name} {transformed_record.get('id')}")
         return False
 
     def process_record(self, record, time_extracted, bookmark_field):


### PR DESCRIPTION
# Description of change
Support ticket: [TDL-25965](https://jira.talendforge.org/browse/TDL-25965).

To implement date windowing logic, generators truncated bookmark and were writing it before processor threads can read. This caused extractions to replicate records with old than current bookmark, increasing the records extracted per job.

Fixed this behaviour by delaying the generator writing first bookmark so that processors can read exact bookmark.

# Manual QA steps
 - Customer verified fix on prod connection
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
