### PR TITLE
Upgrade API version to v2 for loan_repayments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.3.0
+  * Upgrades loan_repayments streams with a comparable endpoint to V2 API. [#123](https://github.com/singer-io/tap-mambu/pull/123)
+  * Updates schemas to match current documentation.
+
 ## 4.2.1
   * Fix the bookmarking for multi-threaded streams [#117](https://github.com/singer-io/tap-mambu/pull/117)
 

--- a/mambu_tests/tap_generators/test_repayments_generator.py
+++ b/mambu_tests/tap_generators/test_repayments_generator.py
@@ -10,4 +10,4 @@ def test_repayments_generator_endpoint_config_init():
 
     assert generator.endpoint_api_key_type is None
     assert generator.endpoint_parent_id == "TEST"
-    assert generator.endpoint_api_version == "v1"
+    assert generator.endpoint_api_version == "v2"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='4.2.1',
+      version='4.3.0',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mambu/helpers/schemas/loan_repayments.json
+++ b/tap_mambu/helpers/schemas/loan_repayments.json
@@ -517,36 +517,6 @@
               "format": "singer.decimal"
             }
           }
-        },
-        "tax": {
-          "type": [
-            "null",
-            "object"
-          ],
-          "additionalProperties": false,
-          "properties": {
-            "due": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "format": "singer.decimal"
-            },
-            "expected": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "format": "singer.decimal"
-            },
-            "paid": {
-              "type": [
-                "null",
-                "string"
-              ],
-              "format": "singer.decimal"
-            }
-          }
         }
       }
     },

--- a/tap_mambu/helpers/schemas/loan_repayments.json
+++ b/tap_mambu/helpers/schemas/loan_repayments.json
@@ -2,63 +2,76 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "assigned_branch_key": {
+    "currency": {
       "type": [
         "null",
-        "string"
-      ]
-    },
-    "assigned_centre_key": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "assigned_user_key": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
-    "custom_settings": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "encoded_key": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "loan_transaction_key": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "source": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "type": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              }
-            }
-          }
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "type": [
+            "null",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "currency_code": {
+          "type": [
+            "null",
+            "string"
+          ]
         }
-      ]
+      }
+    },
+    "carry_forward_interest_split": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "tax": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        }
+      }
+    },
+    "custom_setting_details": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "loan_transaction_key": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "source": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "type": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
     },
     "due_date": {
       "type": [
@@ -73,33 +86,196 @@
         "string"
       ]
     },
-    "fees_applied_due": {
+    "expected_closing_balance": {
       "type": [
         "null",
         "string"
       ],
       "format": "singer.decimal"
     },
-    "fees_due": {
+    "fee": {
       "type": [
         "null",
-        "string"
+        "object"
       ],
-      "format": "singer.decimal"
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "expected": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "expected_unapplied": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "paid": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            }
+          }
+        },
+        "tax": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "expected": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "paid": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            }
+          }
+        }
+      }
     },
-    "fees_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "fees_unapplied_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
+    "fee_details": {
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "amount": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "due": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "singer.decimal"
+                  },
+                  "expected": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "singer.decimal"
+                  },
+                  "paid": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "singer.decimal"
+                  },
+                  "reduced": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "singer.decimal"
+                  }
+                }
+              },
+              "encoded_key": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "id": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "name": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "tax": {
+                "type": [
+                  "null",
+                  "object"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "due": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "singer.decimal"
+                  },
+                  "expected": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "singer.decimal"
+                  },
+                  "paid": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "singer.decimal"
+                  },
+                  "reduced": {
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "format": "singer.decimal"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "funders_interest_due": {
       "type": [
@@ -108,26 +284,87 @@
       ],
       "format": "singer.decimal"
     },
-    "index": {
+    "interest": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "expected": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "paid": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            }
+          }
+        },
+        "tax": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "expected": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "paid": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            }
+          }
+        }
+      }
+    },
+    "interest_accrued": {
       "type": [
         "null",
         "string"
       ],
       "format": "singer.decimal"
     },
-    "interest_due": {
+    "is_payment_holiday": {
       "type": [
         "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "interest_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
+        "boolean"
+      ]
     },
     "last_paid_date": {
       "type": [
@@ -143,7 +380,20 @@
       ],
       "format": "date-time"
     },
+    "non_scheduled_principal_balance_overpayment": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
     "notes": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "number": {
       "type": [
         "null",
         "string"
@@ -162,143 +412,156 @@
         "string"
       ]
     },
-    "penalty_due": {
+    "penalty": {
       "type": [
         "null",
-        "string"
+        "object"
       ],
-      "format": "singer.decimal"
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "expected": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "paid": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            }
+          }
+        },
+        "tax": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "expected": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "paid": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            }
+          }
+        }
+      }
     },
-    "penalty_paid": {
+    "principal": {
       "type": [
         "null",
-        "string"
+        "object"
       ],
-      "format": "singer.decimal"
+      "additionalProperties": false,
+      "properties": {
+        "amount": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "expected": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "paid": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            }
+          }
+        },
+        "tax": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "due": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "expected": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            },
+            "paid": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "singer.decimal"
+            }
+          }
+        }
+      }
     },
-    "principal_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "principal_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "repaid_date": {
+    "repaidDate": {
       "type": [
         "null",
         "string"
       ],
       "format": "date-time"
     },
-    "repayment_unapplied_fee_details": {
-      "anyOf": [
-        {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "encoded_key": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "fee_due": {
-                "type": [
-                  "null",
-                  "string"
-                ],
-                "format": "singer.decimal"
-              },
-              "index_in_list": {
-                "type": [
-                  "null",
-                  "string"
-                ],
-                "format": "singer.decimal"
-              },
-              "predefined_fee_key": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "repayment_key": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "tax_on_fee_due": {
-                "type": [
-                  "null",
-                  "string"
-                ],
-                "format": "singer.decimal"
-              }
-            }
-          }
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "state": {
       "type": [
         "null",
         "string"
       ]
-    },
-    "tax_fees_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "tax_fees_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "tax_interest_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "tax_interest_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "tax_penalty_due": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
-    },
-    "tax_penalty_paid": {
-      "type": [
-        "null",
-        "string"
-      ],
-      "format": "singer.decimal"
     }
   }
 }

--- a/tap_mambu/tap_generators/loan_repayments_generator.py
+++ b/tap_mambu/tap_generators/loan_repayments_generator.py
@@ -1,11 +1,19 @@
 from .child_generator import ChildGenerator
+from .no_pagination_generator import NoPaginationGenerator
 
-
-class LoanRepaymentsGenerator(ChildGenerator):
+class LoanRepaymentsGenerator(NoPaginationGenerator, ChildGenerator):
 
     def _init_endpoint_config(self):
         super(LoanRepaymentsGenerator, self)._init_endpoint_config()
-        self.endpoint_api_version = "v1"
         self.endpoint_api_method = "GET"
         # include parent id in endpoint path
-        self.endpoint_path = f"loans/{self.endpoint_parent_id}/repayments"
+        self.endpoint_path = f"loans/{self.endpoint_parent_id}/schedule"
+
+    def transform_batch(self, batch):
+        batch_installments = batch['installments']
+        batch_currency = batch['currency']
+
+        for installment in batch_installments: 
+            installment['currency'] = batch_currency
+
+        return super(LoanRepaymentsGenerator, self).transform_batch(batch_installments)


### PR DESCRIPTION
# Description of change
- Replace the v1 `/repayments` endpoint with v2 `/schedule` endpoint.([Reference](https://support.mambu.com/docs/revamp-of-mambu-apis#:~:text=GET%20/loans/%7BloanAccountId%7D/repayments,GET%20/loans/%7BloanAccountId%7D/schedule))
- Updates schemas to match current documentation.

# Manual QA steps
 - Verify the primary key for the stream.
 - Verify the number of records synced and compare it with the master branch.
 - Verify all the possible fields available in the API response.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
