### PR TITLE
SAC-28858 meta data changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+
+## 4.4.1
+  * Adds parent-tap-stream-id field to catalog for child streams [#134](https://github.com/singer-io/tap-mambu/pull/134)
+
 ## 4.4.0
   * Upgrades audit_trail and remove activities stream. [#131](https://github.com/singer-io/tap-mambu/pull/131)
   * Updates schemas to match current documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 
-## 4.4.1
+## 4.5.0
   * Adds parent-tap-stream-id field to catalog for child streams [#134](https://github.com/singer-io/tap-mambu/pull/134)
 
 ## 4.4.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='4.4.1',
+      version='4.5.0',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='4.4.0',
+      version='4.4.1',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mambu/helpers/schema.py
+++ b/tap_mambu/helpers/schema.py
@@ -13,7 +13,7 @@ STREAMS = {
     'cards': {
         'key_properties': ['deposit_id', 'reference_token'],
         'replication_method': 'FULL_TABLE',
-        'parent': 'deposits'
+        'parent': 'deposit_accounts'
     },
     'communications': {
         'key_properties': ['encoded_key'],
@@ -66,7 +66,7 @@ STREAMS = {
     'loan_repayments': {
         'key_properties': ['encoded_key'],
         'replication_method': 'FULL_TABLE',
-        'parent': 'loans'
+        'parent': 'loan_accounts'
     },
     'loan_products': {
         'key_properties': ['id'],

--- a/tap_mambu/helpers/schema.py
+++ b/tap_mambu/helpers/schema.py
@@ -12,7 +12,8 @@ STREAMS = {
     },
     'cards': {
         'key_properties': ['deposit_id', 'reference_token'],
-        'replication_method': 'FULL_TABLE'
+        'replication_method': 'FULL_TABLE',
+        'parent': 'deposits'
     },
     'communications': {
         'key_properties': ['encoded_key'],
@@ -64,7 +65,8 @@ STREAMS = {
     },
     'loan_repayments': {
         'key_properties': ['encoded_key'],
-        'replication_method': 'FULL_TABLE'
+        'replication_method': 'FULL_TABLE',
+        'parent': 'loans'
     },
     'loan_products': {
         'key_properties': ['id'],
@@ -148,6 +150,10 @@ def get_schemas():
             valid_replication_keys=stream_metadata.get('replication_keys', None),
             replication_method=stream_metadata.get('replication_method', None)
         )
+
+        parent_stream = stream_metadata.get('parent')
+        if parent_stream:
+            mdata[0]['metadata'].update({"parent-tap-stream-id": parent_stream})
         field_metadata[stream_name] = mdata
 
     return schemas, field_metadata

--- a/tests/base.py
+++ b/tests/base.py
@@ -21,6 +21,7 @@ class MambuBaseTest(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     FULL_TABLE = "FULL_TABLE"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
+    PARENT_TAP_STREAM_ID = "parent-tap-stream-id"
 
     @staticmethod
     def tap_name():
@@ -59,6 +60,7 @@ class MambuBaseTest(unittest.TestCase):
                     "reference_token"
                 },
                 self.REPLICATION_METHOD: "FULL_TABLE",
+                self.PARENT_TAP_STREAM_ID: "deposit_accounts",
             },
             "communications": {
                 self.PRIMARY_KEYS: {
@@ -149,6 +151,7 @@ class MambuBaseTest(unittest.TestCase):
                     "encoded_key"
                 },
                 self.REPLICATION_METHOD: "FULL_TABLE",
+                self.PARENT_TAP_STREAM_ID: "loan_accounts",
             },
             "loan_products": {
                 self.PRIMARY_KEYS: {

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -97,6 +97,19 @@ class DiscoveryTest(MambuBaseTest):
 
                 # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
 
+                expected_parent = self.expected_metadata()[stream].get(self.PARENT_TAP_STREAM_ID)
+                actual_parent = stream_metadata.get(self.PARENT_TAP_STREAM_ID)
+                if expected_parent:
+                    self.assertEqual(
+                        expected_parent,
+                        actual_parent,
+                        msg=f"Expected parent-tap-stream-id '{expected_parent}' but got '{actual_parent}' for stream {stream}"
+                    )
+                else:
+                    self.assertIsNone(
+                        actual_parent,
+                        msg=f"Unexpected parent-tap-stream-id found for stream {stream}: {actual_parent}"
+                    )
 
                 actual_replication_method = stream_metadata.get(self.REPLICATION_METHOD)
 


### PR DESCRIPTION
# Description of change


This PR adds parent stream metadata tracking to the Pepperjam tap by introducing a new `parent_stream` field to stream configurations and updating metadata generation to include parent-tap-stream-id information.

Ticket : [SAC-28871](https://qlik-dev.atlassian.net/browse/SAC-28871)

- Added `parent_stream` field to stream configurations in the flattened streams structure
- Updated metadata generation to include parent-tap-stream-id when a parent stream exists


### Changes

| File | Description |
| ---- | ----------- |
| tap_mambu/helpers/schema.py | Added parent_stream field to both parent and child stream configurations |
| tap_mambu/helpers/schema.py | Updated metadata generation to include parent-tap-stream-id for child streams |





---

# Manual QA steps
You need to comment out the authentication (auth) part in a discovery function, and then generate a log file  to verify the changes.

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
