### PR TITLE
Upgrade api version to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
+## 4.6.0
+  * Update the access_check to use the v2 `/branches` endpoint instead of the v1 `/settings/organization` endpoint. [#132](https://github.com/singer-io/tap-mambu/pull/132)
+  * Replace the v1 `/settings/organization` endpoint with `/setup/organization` to retrieve timezone information.
+  * Add support for the `timezone` new config property
+    * The `/setup/organization` endpoint requires admin permissions. If admin credentials are not provided, the timezone config value will be used as a fallback.
+
 ## 4.5.0
   * Write `timezone` fetched via API in the config. [#135](https://github.com/singer-io/tap-mambu/pull/135)
+  * Revert changes of [#133](https://github.com/singer-io/tap-mambu/pull/133)
 
 ## 4.4.1
   * Replace /users with /branches endpoint [#133](https://github.com/singer-io/tap-mambu/pull/133)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.4.0
+  * Update the access_check to use the v2 `/users` endpoint instead of the v1 `/settings/organization` endpoint. [#132](https://github.com/singer-io/tap-mambu/pull/132)
+  * Replace the v1 `/settings/organization` endpoint with `/setup/organization` to retrieve timezone information.
+  * Add support for the `timezone` new config property
+    * The `/setup/organization` endpoint requires admin permissions. If admin credentials are not provided, the timezone config value will be used as a fallback.
 ## 4.3.1
   * Bump dependency versions for twistlock compliance [#124](https://github.com/singer-io/tap-mambu/pull/123)
 

--- a/README.md
+++ b/README.md
@@ -255,12 +255,15 @@ This tap:
         "user_agent": "tap-mambu <api_user_email@your_company.com>",
         "page_size": "500",
         "apikey_audit": "AUDIT_TRAIL_APIKEY",
-        "window_size": 7
+        "window_size": 7,
+        "timezone": "US/Pacific"
     }
     ```
 
     Note: The `window_size` parameter defaults to 1 day, which may cause slowdowns in historical sync for streams utilizing multi-threaded implementation. Conversely, using a larger `window_size` could lead to potential `out-of-memory` issues. It is advisable to select an optimal `window_size` based on the `start_date` and volume of data to mitigate these concerns.
 
+    The `timezone` represents your organization's local timezone. To find the [timezone](https://support.mambu.com/docs/organization-contact-currency-and-timezone) information, go to the main menu and go to Administration > General Setup > Organization Details > Time Zone
+  
     Optionally, also create a `state.json` file. `currently_syncing` is an optional attribute used for identifying the last object to be synced in case the job is interrupted mid-stream. The next run would begin where the last job left off.
 
     ```json

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='4.5.0',
+      version='4.6.0',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-mambu',
-      version='4.3.1',
+      version='4.4.0',
       description='Singer.io tap for extracting data from the Mambu 2.0 API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_mambu/__init__.py
+++ b/tap_mambu/__init__.py
@@ -47,7 +47,6 @@ def main():
         elif parsed_args.catalog:
             sync_all_streams(client=client,
                              config=parsed_args.config,
-                             config_path=parsed_args.config_path,
                              catalog=parsed_args.catalog,
                              state=state)
 

--- a/tap_mambu/helpers/client.py
+++ b/tap_mambu/helpers/client.py
@@ -168,7 +168,7 @@ class MambuClient(object):
         headers = {}
         # Endpoint: simple API call to return a single record (org settings) to test access
         # https://support.mambu.com/docs/organisational-settings-api#get-organisational-settings
-        endpoint = 'users'
+        endpoint = 'branches'
         url = '{}/{}'.format(self.base_url, endpoint)
         headers['User-Agent'] = self.__user_agent
         headers['Accept'] = 'application/vnd.mambu.v2+json'

--- a/tap_mambu/helpers/client.py
+++ b/tap_mambu/helpers/client.py
@@ -168,10 +168,10 @@ class MambuClient(object):
         headers = {}
         # Endpoint: simple API call to return a single record (org settings) to test access
         # https://support.mambu.com/docs/organisational-settings-api#get-organisational-settings
-        endpoint = 'settings/organization'
+        endpoint = 'users'
         url = '{}/{}'.format(self.base_url, endpoint)
         headers['User-Agent'] = self.__user_agent
-        headers['Accept'] = 'application/vnd.mambu.v1+json'
+        headers['Accept'] = 'application/vnd.mambu.v2+json'
         if use_apikey:
             # Api Key API Consumer Authentication: https://support.mambu.com/docs/api-consumers
             self.__session.headers['apikey'] = self.__apikey

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -30,17 +30,8 @@ def sync_endpoint(client, catalog, state,
 
     return processor.process_streams_from_generators()
 
-def _write_config(config, config_path, _timezone):
-    with open(config_path, encoding='utf-8') as file:
-        config = json.load(file)
 
-    config['timezone'] = _timezone
-    with open(config_path, 'w', encoding='utf-8') as file:
-        json.dump(config, file, indent=2)
-
-    LOGGER.info("timezone has been updated in config")
-
-def sync_all_streams(client, config, config_path, catalog, state):
+def sync_all_streams(client, config, catalog, state):
     from .tap_generators.child_generator import ChildGenerator
     from .tap_processors.child_processor import ChildProcessor
 

--- a/tap_mambu/sync.py
+++ b/tap_mambu/sync.py
@@ -35,7 +35,7 @@ def sync_all_streams(client, config, catalog, state):
     from .tap_generators.child_generator import ChildGenerator
     from .tap_processors.child_processor import ChildProcessor
 
-    get_timezone_info(client)
+    get_timezone_info(client, config_timezone=config.get("timezone"))
 
     selected_streams = get_selected_streams(catalog)
     LOGGER.info('selected_streams: {}'.format(selected_streams))

--- a/tests/base.py
+++ b/tests/base.py
@@ -250,6 +250,7 @@ class MambuBaseTest(unittest.TestCase):
             'username': os.environ['TAP_MAMBU_USERNAME'],
             'subdomain': os.environ['TAP_MAMBU_SUBDOMAIN'],
             'page_size': '90',
+            'timezone': 'US/Pacific',
             'window_size': 30
         }
 

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -53,7 +53,7 @@ def test_client_check_access_api_key(mock_requests_session_get):
     assert client.base_url == base_url
     assert client.page_size == DEFAULT_PAGE_SIZE
 
-    mock_requests_session_get.assert_called_once_with(url=f'{base_url}/users',
+    mock_requests_session_get.assert_called_once_with(url=f'{base_url}/branches',
                                                       headers={'Accept': 'application/vnd.mambu.v2+json',
                                                                'User-Agent': 'MambuTap-User_Agent_Test'})
 
@@ -77,7 +77,7 @@ def test_client_check_access_user_pass(mock_requests_session_get):
     assert client.base_url == base_url
     assert client.page_size == 100
 
-    mock_requests_session_get.assert_called_once_with(url=f'{base_url}/users',
+    mock_requests_session_get.assert_called_once_with(url=f'{base_url}/branches',
                                                       headers={'Accept': 'application/vnd.mambu.v2+json',
                                                                'User-Agent': 'MambuTap'})
 

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -53,8 +53,8 @@ def test_client_check_access_api_key(mock_requests_session_get):
     assert client.base_url == base_url
     assert client.page_size == DEFAULT_PAGE_SIZE
 
-    mock_requests_session_get.assert_called_once_with(url=f'{base_url}/settings/organization',
-                                                      headers={'Accept': 'application/vnd.mambu.v1+json',
+    mock_requests_session_get.assert_called_once_with(url=f'{base_url}/users',
+                                                      headers={'Accept': 'application/vnd.mambu.v2+json',
                                                                'User-Agent': 'MambuTap-User_Agent_Test'})
 
 
@@ -77,8 +77,8 @@ def test_client_check_access_user_pass(mock_requests_session_get):
     assert client.base_url == base_url
     assert client.page_size == 100
 
-    mock_requests_session_get.assert_called_once_with(url=f'{base_url}/settings/organization',
-                                                      headers={'Accept': 'application/vnd.mambu.v1+json',
+    mock_requests_session_get.assert_called_once_with(url=f'{base_url}/users',
+                                                      headers={'Accept': 'application/vnd.mambu.v2+json',
                                                                'User-Agent': 'MambuTap'})
 
 


### PR DESCRIPTION
# Description of change
Revert #[135](https://github.com/singer-io/tap-mambu/pull/135) changes

We are upgrading API version for mambu to v2.
In v1, we were using settings/organization to fetch the timezone info. In v2, setup/organization is the replacement of this endpoint but it requires admin permission and there’s no other way to fetch timezone info via API without that access. So, we have added configurable property timezone which we would use in case if customer has not provided admin creds.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
