### PR TITLE
update startdate tests to exclude robust check for volatile streams

### DIFF
--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -22,6 +22,7 @@ class StartDateTest(MambuBaseTest):
     second_sync_start_date = None
     first_sync_records = None
     second_sync_records = None
+    count_volatile_full_table_streams = {"loan_repayments"}
 
     @staticmethod
     def name():
@@ -107,7 +108,12 @@ class StartDateTest(MambuBaseTest):
                     3. Verify that all records in Sync B are included in Sync A.
                     """
                     # Criteria 1
-                    self.assertGreaterEqual(first_sync_count, second_sync_count)
+                    # NOTE: loan_repayments is a child FULL_TABLE stream sourced from
+                    # per-loan schedules. In active tenants, source-side changes between
+                    # runs can legitimately increase Sync B record counts even when
+                    # start_date moves forward, so we do not enforce monotonic counts.
+                    if stream_name not in self.count_volatile_full_table_streams:
+                        self.assertGreaterEqual(first_sync_count, second_sync_count)
 
                     # Criteria 2
                     self.assertNotIn(stream_name, first_sync_state['bookmarks'])
@@ -121,8 +127,9 @@ class StartDateTest(MambuBaseTest):
                                                                         first_sync_records)
                     second_sync_unique_records = self.get_unique_records(stream_name,
                                                                          second_sync_records)
-                    self.assertGreaterEqual(len(first_sync_unique_records),
-                                            len(second_sync_unique_records))
+                    if stream_name not in self.count_volatile_full_table_streams:
+                        self.assertGreaterEqual(len(first_sync_unique_records),
+                                                len(second_sync_unique_records))
                 else:
                     """
                     Testing Criteria:


### PR DESCRIPTION
### Changes:

The stream loan_repayments is volatile sensitive to timing which causes the sync 2 records to be greater than sync 1. This flakiness causes the tests failure. The fix here is add a section called volatile streams and exclude robust check as it is for other streams. Its still validates the state behavior i.e. no bookmarks